### PR TITLE
NCEPLIBS-wgrib2 cmake build updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,14 +31,12 @@ option(USE_JASPER "Use Jasper?" on)
 option(USE_AEC "Use AEC?" off)
 
 
-# DH* ??? if the "... must be off" statements are correct, the 
-# test should be for if (USE_PNG) and if(USE_JASPER) *DH
 if(USE_G2CLIB) 
-    if(not USE_PNG) 
+    if(USE_PNG) 
         message(FATAL_ERROR "If USE_G2CLIB is on, USE_PNG must be off")
     endif()
 
-    if(not USE_JASPER) 
+    if(USE_JASPER) 
         message(FATAL_ERROR "If USE_G2CLIB is on, USE_JASPER must be off")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ option(USE_JASPER "Use Jasper?" on)
 option(USE_AEC "Use AEC?" off)
 
 
+# DH* ??? if the "... must be off" statements are correct, the 
+# test should be for if (USE_PNG) and if(USE_JASPER) *DH
 if(USE_G2CLIB) 
     if(not USE_PNG) 
         message(FATAL_ERROR "If USE_G2CLIB is on, USE_PNG must be off")

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -16,7 +16,6 @@ add_library(obj_lib OBJECT ${lib_src})
 target_compile_definitions(obj_lib PUBLIC ${definitions_list}) 
 
 # with -DCALLABLE_WGRIB2 for the lib
-#add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> ${callable_src})
 add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
 # library and executable have same name (wgrib2) but different target names
 set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(obj_lib OBJECT ${lib_src})
 target_compile_definitions(obj_lib PUBLIC ${definitions_list}) 
 
 # with -DCALLABLE_WGRIB2 for the lib
-add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> ${callable_src})
+#add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> ${callable_src})
+add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
 # library and executable have same name (wgrib2) but different target names
 set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)
 


### PR DESCRIPTION
This PR
- updates the submodule pointer for CMakeModules to tag v1.1.0
- adds the gctpc objects to the wgrib2 library
- contains one comment in the top-level `CMakeLists.txt` about some code I am not sure if it is correct; @kgerheiser can you please check my comment in this file?