### PR TITLE
Make install relocatable by not hard-wiring include path

### DIFF
--- a/ftn_api/CMakeLists.txt
+++ b/ftn_api/CMakeLists.txt
@@ -15,13 +15,11 @@ add_library(wgrib2_api ${fortran_src} ${c_src})
 set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include")
 set_target_properties(wgrib2_api PROPERTIES Fortran_MODULE_DIRECTORY ${module_dir})
 
-
-
 target_include_directories(wgrib2_api
     PUBLIC $<BUILD_INTERFACE:${module_dir}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+    $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(wgrib2_api PUBLIC wgrib2_lib)  
+target_link_libraries(wgrib2_api PUBLIC wgrib2_lib)
 
 install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
 

--- a/wgrib2/gctpc/source/CMakeLists.txt
+++ b/wgrib2/gctpc/source/CMakeLists.txt
@@ -80,7 +80,7 @@ add_library(gctpc OBJECT ${src})
 
 target_include_directories(gctpc PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+  $<INSTALL_INTERFACE:include>)
   
 install(
   TARGETS gctpc


### PR DESCRIPTION
This should remove hard-coded references to the install path