### PR TITLE
Option for shared/static build and prefer .a over .so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ option(USE_PNG "Use PNG?" on)
 option(USE_JASPER "Use Jasper?" on)
 option(USE_AEC "Use AEC?" off)
 
+option(BUILD_SHARED_LIB "Build shared library?" off)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" ".so")
 
 if(USE_G2CLIB) 
     if(not USE_PNG) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ list(APPEND definitions_list -DUSE_IPOLATES=${USE_IPOLATES})
 
 if(USE_NETCDF4)
   find_package(NetCDF MODULE REQUIRED COMPONENTS C)
+  set(HDF5_USE_STATIC_LIBRARIES ON)
+  find_package(HDF5 COMPONENTS C HL)
   list(APPEND definitions_list -DUSE_NETCDF4 -DUSE_HDF5 -DHDF5="hdf5")
 endif()
 

--- a/build_all.sh
+++ b/build_all.sh
@@ -75,6 +75,7 @@ elif [ $machine = 'dell' ]; then
   export FC=ifort
   module load sp/2.0.2
   module load ip2/1.0.0
+  module load HDF5-serial/1.10.1
   module load NetCDF/4.5.0
   export Jasper_ROOT="/usrx/local/prod/packages/gnu/4.8.5/jasper/1.900.1"
 else

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
 endif()
 
 if(USE_NETCDF4)
-  target_link_libraries(wgrib2_exe PUBLIC ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
+  target_link_libraries(wgrib2_exe PUBLIC ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})
 endif()
 
 install(

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -17,7 +17,13 @@ target_compile_definitions(obj_lib PUBLIC ${definitions_list})
 target_link_libraries(obj_lib PRIVATE gctpc)
 
 # with -DCALLABLE_WGRIB2 for the lib
-add_library(wgrib2_lib $<TARGET_OBJECTS:obj_lib> ${callable_src})
+if(BUILD_SHARED_LIB)
+  add_library(wgrib2_lib SHARED $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
+else()
+  add_library(wgrib2_lib STATIC $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
+endif()
+
+# with -DCALLABLE_WGRIB2 for the lib
 set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)
 target_compile_definitions(wgrib2_lib PRIVATE CALLABLE_WGRIB2)
 target_link_libraries(wgrib2_lib PUBLIC gctpc)

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -74,6 +74,10 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   target_link_libraries(wgrib2_exe PRIVATE "-lgfortran")
 endif()
 
+if(USE_NETCDF4)
+  target_link_libraries(wgrib2_exe PUBLIC ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
+endif()
+
 install(
   TARGETS wgrib2_lib wgrib2_exe
   EXPORT wgrib2_exports


### PR DESCRIPTION
Could you please try this out @GeorgeGayno-NOAA 

It will build a static library by default and will prefer static libraries when doing `find_package`