### PR TITLE
Simple library build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 include(GNUInstallDirs)
 
 option(USE_NETCDF3 "Use NetCDF-3?" off)
-option(USE_NETCDF4 "Use NetCDF-4?" on)
+option(USE_NETCDF4 "Use NetCDF-4?" off)
 option(USE_REGEX "Use Regex?" on)
 option(USE_TIGGE "Use tigge?" on)
 option(USE_MYSQL "Use MySQL?" off)
@@ -32,6 +32,7 @@ option(USE_PNG "Use PNG?" on)
 option(USE_JASPER "Use Jasper?" on)
 option(USE_AEC "Use AEC?" off)
 
+option(BUILD_LIB "Build wgrib2 library?" on)
 option(BUILD_SHARED_LIB "Build shared library?" off)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 #set default install path if not provided
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX
-      "${CMAKE_BINARY_DIR}/install"
-      CACHE PATH "default install path" FORCE)
+    "${CMAKE_BINARY_DIR}/install"
+    CACHE PATH "default install path" FORCE)
 endif()
 
 include(GNUInstallDirs)
@@ -24,7 +24,6 @@ option(OPENMP "Use OpenMP?" off)
 option(USE_PROJ4 "Use Proj4?" off)
 option(USE_WMO_VALIDATION "Use WMO Validation?" off)
 option(DISABLE_TIMEZONE "Disable Timezone?" off)
-option(MAKE_FTN_API "Make Fortran API?" on)
 option(DISABLE_ALARM "Disable Alarm?" off)
 
 option(USE_G2CLIB "Use g2c lib?" off)
@@ -37,44 +36,44 @@ option(BUILD_SHARED_LIB "Build shared library?" off)
 
 
 if(USE_G2CLIB) 
-    if(USE_PNG) 
-        message(FATAL_ERROR "If USE_G2CLIB is on, USE_PNG must be off")
-    endif()
+  if(USE_PNG) 
+    message(FATAL_ERROR "If USE_G2CLIB is on, USE_PNG must be off")
+  endif()
 
-    if(USE_JASPER) 
-        message(FATAL_ERROR "If USE_G2CLIB is on, USE_JASPER must be off")
-    endif()
+  if(USE_JASPER) 
+    message(FATAL_ERROR "If USE_G2CLIB is on, USE_JASPER must be off")
+  endif()
 endif()
 
 
 if(USE_SPECTRAL)
-    if(NOT USE_IPOLATES EQUAL 3)
-        message(FATAL_ERROR "If USE_SPECTRAL is on, USE_IPOLATES must be 3")
-    endif()
+  if(NOT USE_IPOLATES EQUAL 3)
+    message(FATAL_ERROR "If USE_SPECTRAL is on, USE_IPOLATES must be 3")
+  endif()
 endif()
 
 if(USE_NETCDF3 AND USE_NETCDF4)
-    message(FATAL_ERROR "USE_NETCDF3 OR USE_NetCDF4, not both")
+  message(FATAL_ERROR "USE_NETCDF3 OR USE_NetCDF4, not both")
 endif()
 
 if(USE_REGEX) 
-    list(APPEND definitions_list -DUSE_REGEX)
+  list(APPEND definitions_list -DUSE_REGEX)
 endif()
 
 if(USE_TIGGE)
-    list(APPEND  -DUSE_TIGGE)
+  list(APPEND  -DUSE_TIGGE)
 endif()
 
 if(DISABLE_ALARM)
-    list(APPEND definitions_list -DDISABLE_ALARM)
+  list(APPEND definitions_list -DDISABLE_ALARM)
 endif()
 
 if(DISABLE_TIMEZONE)
-    list(APPEND definitions_list -DDISABLE_TIMEZONE)
+  list(APPEND definitions_list -DDISABLE_TIMEZONE)
 endif()
 
 if(USE_UDF)
-    list(APPEND definitions_list -DUSE_UDF)
+  list(APPEND definitions_list -DUSE_UDF)
 endif()
 
 if(USE_IPOLATES EQUAL 1)
@@ -104,16 +103,16 @@ if(USE_JASPER)
 endif()
 
 if(OPENMP)
-    list(APPEND definitions_list -DUSE_OPENMP)
-    find_package(OpenMP)
+  list(APPEND definitions_list -DUSE_OPENMP)
+  find_package(OpenMP)
 endif()
 
 if(USE_G2CLIB) 
-    list(APPEND definitions_list -DUSE_G2CLIB)
+  list(APPEND definitions_list -DUSE_G2CLIB)
 endif()
 
 if(USE_PROJ4)
-    list(APPEND definitions_list -DUSE_PROJ4)
+  list(APPEND definitions_list -DUSE_PROJ4)
 endif()
 
 if(USE_PNG)
@@ -122,40 +121,41 @@ if(USE_PNG)
 endif()
 
 if(USE_WMO_VALIDATION)
-    list(APPEND definitions_list -DUSE_WMO_VALIDATION)
+  list(APPEND definitions_list -DUSE_WMO_VALIDATION)
 endif()
 
 add_subdirectory(wgrib2)
 add_subdirectory(aux_progs)
 
-if(MAKE_FTN_API)
+
+if(BUILD_LIB)
   add_subdirectory(ftn_api)
+
+  ### Package config
+  include(CMakePackageConfigHelpers)
+  set(CONFIG_INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+
+  # No need for config file if library isn't built
+  export(EXPORT wgrib2_exports
+    NAMESPACE wgrib2::
+    FILE wgrib2-targets.cmake)
+
+  configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/PackageConfig.cmake.in ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
+  install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+    DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+  write_basic_package_version_file(
+    ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+  install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
+    DESTINATION ${CONFIG_INSTALL_DESTINATION})
+
+  install(EXPORT wgrib2_exports
+    NAMESPACE wgrib2::
+    FILE wgrib2-targets.cmake
+    DESTINATION ${CONFIG_INSTALL_DESTINATION})
 endif()
 
-
-
-### Package config
-include(CMakePackageConfigHelpers)
-set(CONFIG_INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
-
-export(EXPORT wgrib2_exports
-  NAMESPACE wgrib2::
-  FILE wgrib2-targets.cmake)
-
-configure_package_config_file(
-  ${CMAKE_SOURCE_DIR}/cmake/PackageConfig.cmake.in ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-  INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
-install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})
-
-write_basic_package_version_file(
-  ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-  VERSION ${PROJECT_VERSION}
-  COMPATIBILITY AnyNewerVersion)
-install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})
-
-install(EXPORT wgrib2_exports
-  NAMESPACE wgrib2::
-  FILE wgrib2-targets.cmake
-  DESTINATION ${CONFIG_INSTALL_DESTINATION})

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -9,26 +9,6 @@ include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
 include(CMakeFindDependencyMacro)
 
-if(@USE_NETCDF4@)
-  find_dependency(NetCDF)
-endif()
-
-if(@USE_JASPER@)
-  find_dependency(Jasper)
-endif()
-
-if(@USE_PNG@)
-  find_dependency(PNG)
-endif()
-
-if(@USE_IPOLATES@ EQUAL 3)
-  find_dependency(ip2)
-endif()
-
-if(@OPENMP@)
-  find_dependency(OpenMP)
-endif()
-
 #get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IMPORTED_CONFIGURATIONS)
 
 check_required_components("@PROJECT_NAME@")

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -3,10 +3,10 @@
 include("source-files.cmake")
 
 set(callable_src
-    wgrib2.c
-    fatal_error.c
-    wgrib2_api.c
-)   
+  wgrib2.c
+  fatal_error.c
+  wgrib2_api.c
+  )   
 
 add_subdirectory(gctpc)
 # make this an object lib so we can re-use most of object files
@@ -22,12 +22,12 @@ if(BUILD_LIB)
   else()
     add_library(wgrib2_lib STATIC ${lib_src} $<TARGET_OBJECTS:gctpc> ${callable_src})
   endif()
+
+  # library and executable have same name (wgrib2) but different target names
+  set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)
+  target_compile_definitions(wgrib2_lib PRIVATE CALLABLE_WGRIB2 USE_REGEX)
 endif()
 
-# library and executable have same name (wgrib2) but different target names
-set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)
-
-target_compile_definitions(wgrib2_lib PRIVATE CALLABLE_WGRIB2 USE_REGEX)
 
 # without -DCALLABLE_WGRIB2 for the executable
 add_executable(wgrib2_exe ${callable_src})
@@ -48,9 +48,6 @@ endif()
 
 if(OpenMP_FOUND)
   target_link_libraries(obj_lib PUBLIC OpenMP::OpenMP_C)
-endif()
-
-if(USE_SPECTRAL)
 endif()
 
 if(USE_G2CLIB)
@@ -74,16 +71,25 @@ target_link_libraries(obj_lib PUBLIC gctpc -lm)
 
 # Link to gctpc directly because oobject libraries do not link transitively
 target_link_libraries(wgrib2_exe PRIVATE gctpc)
-target_link_libraries(wgrib2_lib PUBLIC gctpc)
-
 target_link_libraries(wgrib2_exe PRIVATE obj_lib)
 
-set(headers wgrib2_api.h wgrib2.h)
+if(BUILD_LIB)
+  set(headers wgrib2_api.h wgrib2.h)
+  target_link_libraries(wgrib2_lib PUBLIC gctpc)
+  set_target_properties(wgrib2_lib PROPERTIES PUBLIC_HEADER "${headers}")
 
-set_target_properties(wgrib2_lib PROPERTIES PUBLIC_HEADER "${headers}")
+  install(
+    TARGETS wgrib2_lib
+    EXPORT wgrib2_exports
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+  
+endif()
 
 install(
-  TARGETS wgrib2_lib wgrib2_exe obj_lib
+  TARGETS wgrib2_exe obj_lib
   EXPORT wgrib2_exports
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -15,17 +15,19 @@ add_subdirectory(gctpc)
 add_library(obj_lib OBJECT ${lib_src})
 target_compile_definitions(obj_lib PUBLIC ${definitions_list}) 
 
-# with -DCALLABLE_WGRIB2 for the lib
-if(BUILD_SHARED_LIB)
-  add_library(wgrib2_lib SHARED $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
-else()
-  add_library(wgrib2_lib STATIC $<TARGET_OBJECTS:obj_lib> $<TARGET_OBJECTS:gctpc> ${callable_src})
+if(BUILD_LIB)
+  # with -DCALLABLE_WGRIB2 for the lib
+  if(BUILD_SHARED_LIB)
+    add_library(wgrib2_lib SHARED ${lib_src} $<TARGET_OBJECTS:gctpc> ${callable_src})
+  else()
+    add_library(wgrib2_lib STATIC ${lib_src} $<TARGET_OBJECTS:gctpc> ${callable_src})
+  endif()
 endif()
 
 # library and executable have same name (wgrib2) but different target names
 set_target_properties(wgrib2_lib PROPERTIES OUTPUT_NAME wgrib2)
 
-target_compile_definitions(wgrib2_lib PRIVATE CALLABLE_WGRIB2)
+target_compile_definitions(wgrib2_lib PRIVATE CALLABLE_WGRIB2 USE_REGEX)
 
 # without -DCALLABLE_WGRIB2 for the executable
 add_executable(wgrib2_exe ${callable_src})
@@ -75,7 +77,6 @@ target_link_libraries(wgrib2_exe PRIVATE gctpc)
 target_link_libraries(wgrib2_lib PUBLIC gctpc)
 
 target_link_libraries(wgrib2_exe PRIVATE obj_lib)
-target_link_libraries(wgrib2_lib PRIVATE obj_lib)
 
 set(headers wgrib2_api.h wgrib2.h)
 


### PR DESCRIPTION
Fixes #33 

The library is built without third-party libraries such as Jasper or NetCDF. This is the way is the library is used by UFS_UTILS. 

Now the library and executable can be built in a single build without having to delete the library and then re-running CMake.

This is controlled by the option `BUILD_LIB`, which is off by default.

Thoughts @GeorgeGayno-NOAA?