### PR TITLE
Check OpenMP_C_FOUND instead of OpenMP_FOUND

### DIFF
--- a/wgrib2/CMakeLists.txt
+++ b/wgrib2/CMakeLists.txt
@@ -46,7 +46,7 @@ if(USE_PNG)
   target_link_libraries(obj_lib PUBLIC PNG::PNG)
 endif()
 
-if(OpenMP_FOUND)
+if(OpenMP_C_FOUND)
   target_link_libraries(obj_lib PUBLIC OpenMP::OpenMP_C)
 endif()
 


### PR DESCRIPTION
OpenMP_FOUND can be true if the Fortran OpenMP library was found. Specifically check if OpenMP_C_FOUND instead.

Fixes #45 