### PR TITLE
add missing set -e to jpeg tests

### DIFF
--- a/tests/run_jpeg_tests.sh
+++ b/tests/run_jpeg_tests.sh
@@ -4,6 +4,10 @@
 #
 # Alyson Stahl 7/26/2024
 
+set -e
+echo ""
+echo "*** Running wgrib2 jpeg tests"
+
 echo "*** Converting from jpeg to simple packing"
 ../wgrib2/wgrib2 data/gdaswave.t00z.wcoast.0p16.f000.grib2 -set_grib_type simple -grib_out jpeg2simple.grb
 ../wgrib2/wgrib2 jpeg2simple.grb -v2 -s >  jpeg2simple.txt


### PR DESCRIPTION
This line was missing from the run_jpeg_tests.sh file.