### PR TITLE
Use spack repo cache so spack workflows run faster

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -31,6 +31,7 @@ jobs:
         package-name: wgrib2
         package-variants: ${{ matrix.variants }}
         custom-recipe: spack/package.py
+        use-repo-cache: true
         spack-compiler: gcc
         repo-cache-key-suffix: ${{ matrix.os }}-${{ matrix.variants }}-1
 


### PR DESCRIPTION
We were already caching the spack builds, but the workflow wasn't using them since "use-repo-cache" is false by default. As a result, the spack checks have been running unnecessarily slowly.