### PR TITLE
Update upload-pages-artifact to v3 in developer workflow

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -82,6 +82,6 @@ jobs:
           wgrib2/build/*.css
 
     - name: Upload built documentation
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: wgrib2/build/docs/html  # Path to the built site files


### PR DESCRIPTION
Fixes #318 

actions/upload-pages-artifact@v1 calls actions/upload-artifact@v3, which is now deprecated. 