### PR TITLE
Replace build options with new "USE_G2CLIB_LOW" option in workflows

### DIFF
--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -37,7 +37,7 @@ jobs:
             options: "-DBUILD_WGRIB=ON"
           }
         - {
-            options: "-DUSE_OPENJPEG=ON"
+            options: "-DUSE_G2CLIB_LOW=ON"
           }
         gcc-version: [12]
         include:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -60,7 +60,7 @@ jobs:
         mkdir build
         cd build
         #export CFLAGS='-I/Users/runner/work/wgrib2/wgrib2/nceplibs/NCEPLIBS-g2c/include'
-        cmake -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" .. -DUSE_AEC=ON -DUSE_PNG=ON -DUSE_JASPER=${{matrix.jasper}} -DUSE_OPENJPEG=${{matrix.openjpeg}} -DBUILD_SHARED_LIB=${{matrix.sharedlib}} -DMAKE_FTN_API=ON
+        cmake -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip" .. -DUSE_AEC=ON -DUSE_G2CLIB_LOW=ON -DBUILD_SHARED_LIB=${{matrix.sharedlib}} -DMAKE_FTN_API=ON
         make VERBOSE=1
     
     - name: test

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -62,7 +62,7 @@ jobs:
         export CFLAGS='-Wall -g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -I/home/runner/work/wgrib2/wgrib2/nceplibs/NCEPLIBS-g2c/include'
         export FCFLAGS='-Wall -g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0'
         export FFLAGS='-Wall -g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0'
-        cmake .. -DENABLE_DOCS=ON -DFTP_TEST_FILES=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip;$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c" -DTEST_FILE_DIR=/home/runner/data -DMAKE_FTN_API=ON -DUSE_NETCDF4=ON -DUSE_AEC=ON -DUSE_IPOLATES=ON -DUSE_JASPER=ON -DUSE_PNG=ON
+        cmake .. -DENABLE_DOCS=ON -DFTP_TEST_FILES=ON -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-ip;$GITHUB_WORKSPACE/nceplibs/jasper;$GITHUB_WORKSPACE/nceplibs/NCEPLIBS-g2c" -DTEST_FILE_DIR=/home/runner/data -DMAKE_FTN_API=ON -DUSE_NETCDF4=ON -DUSE_AEC=ON -DUSE_IPOLATES=ON -DG2CLIB_LOW=ON
         make VERBOSE=1
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null


### PR DESCRIPTION
Part of #336 