### PR TITLE
Update package.py for v3.7.0 and g2c v2.2.0 requirements

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -195,8 +195,8 @@ class Wgrib2(MakefilePackage, CMakePackage):
     conflicts("-g2c", when="+g2c_high")
 
     depends_on("ip@5.2:", when="@develop +ipolates")
-    depends_on("g2c@2.2.0:", when="@develop +g2c")
-    depends_on("g2c@2.2.0:", when="@develop +g2c_high")
+    depends_on("g2c@2.2.0:", when="@3.7: +g2c")
+    depends_on("g2c@2.2.0:", when="@3.7: +g2c_high")
     depends_on("lapack", when="@develop +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
     depends_on("netcdf-c", when="@3.2: +netcdf4")

--- a/spack/package.py
+++ b/spack/package.py
@@ -19,6 +19,8 @@ variant_map_common = {
     "tigge": "USE_TIGGE",
     "proj4": "USE_PROJ4",
     "aec": "USE_AEC",
+    "png": "USE_PNG",
+    "jasper": "USE_JASPER",
     "g2c": "USE_G2CLIB_LOW",
     "g2c_high": "USE_G2CLIB_HIGH",
     "openmp": "USE_OPENMP",
@@ -27,7 +29,7 @@ variant_map_common = {
     "disable_alarm": "DISABLE_ALARM",
     "fortran_api": "MAKE_FTN_API",
     "disable_stat": "DISABLE_STAT",
-    
+    "openjpeg": "USE_OPENJPEG",
 }
 
 variant_map_makefile = { 
@@ -55,6 +57,7 @@ class Wgrib2(MakefilePackage, CMakePackage):
     build_system(conditional("cmake", when="@3.2:"), conditional("makefile", when="@:3.1"))
 
     version("develop", branch="develop")
+    version("3.7.0", sha256="b741a07710a8195c99a7d50de05bde90182ab4334f5c4a0d6d057c4e20cc6a75")
     version("3.6.0", sha256="55913cb58f2b329759de17f5a84dd97ad1844d7a93956d245ec94f4264d802be")
     version("3.5.0", sha256="b27b48228442a08bddc3d511d0c6335afca47252ae9f0e41ef6948f804afa3a1")
     version("3.4.0", sha256="ecbce2209c09bd63f1bca824f58a60aa89db6762603bda7d7d3fa2148b4a0536")
@@ -149,17 +152,16 @@ class Wgrib2(MakefilePackage, CMakePackage):
     )
     variant(
         "g2c",
-        default=False,
+        default=True,
         description="Include NCEP g2clib (png,jpeg2000)",
-        when="@:3.1",
+        when="@3.7:",
     )
     variant(
         "g2c_high",
         default=False,
         description="Include NCEP g2clib (add -g2clib 2)",
-        when="@:3.1",
+        when="@3.7:",
     )
-
     variant(
         "disable_timezone", default=False, description="Some machines do not support timezones"
     )
@@ -168,10 +170,23 @@ class Wgrib2(MakefilePackage, CMakePackage):
         default=False,
         description="Some machines do not support the alarm to terminate wgrib2",
     )
+    variant(
+        "png", 
+        default=True, 
+        description="PNG encoding",
+        when="@:3.7"
+    )
+    variant(
+        "jasper", 
+        default=True, 
+        description="JPEG compression using Jasper",
+        when="@:3.7"
+    )
     variant("openmp", default=True, description="OpenMP parallelization")
     variant("wmo_validation", default=False, description="WMO validation")
     #    variant("shared", default=False, description="Enable shared library", when="+lib")
     variant("disable_stat", default=False, description="Disable POSIX feature", when="@:3.1")
+    variant("openjpeg", default=False, description="Enable OpenJPEG", when="@:3.7")
     variant("enable_docs", default=False, description="Build doxygen documentation", when="@3.4.0:")
 
     conflicts("+netcdf3", when="+netcdf4")
@@ -180,10 +195,19 @@ class Wgrib2(MakefilePackage, CMakePackage):
     conflicts("-g2c", when="+g2c_high")
 
     depends_on("ip@5.2:", when="@develop +ipolates")
-    depends_on("g2c@develop", when="@develop +g2c")
+    depends_on("g2c@2.2.0:", when="@develop +g2c")
+    depends_on("g2c@2.2.0:", when="@develop +g2c_high")
     depends_on("lapack", when="@develop +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
     depends_on("netcdf-c", when="@3.2: +netcdf4")
+
+    depends_on("jasper@:2", when="@3.2:3.4 +jasper")
+    depends_on("g2c@2.2.0: +jasper", when="@3.4:3.7 +jasper")
+    depends_on("zlib-api", when="@3.2:3.4 +png")
+    depends_on("libpng", when="@3.2:3.4 +png")
+    depends_on("g2c@2.2.0: +png", when="@3.4:3.7 +png")
+    depends_on("openjpeg", when="@3.2:3.4 +openjpeg")
+    depends_on("g2c@2.2.0: +openjpeg", when="@3.4:3.7 +openjpeg")
 
     @when("@:2 ^gmake@4.2:")
 


### PR DESCRIPTION
Fixes #360 

Some variants were erroneously removed when we updated some of the cmake options. Those were added back in and updated for recent release requirements.