### PR TITLE
Change gribtable lookup to fix #377

### DIFF
--- a/wgrib2/cname.c
+++ b/wgrib2/cname.c
@@ -147,6 +147,7 @@ static struct gribtable_s *search_gribtable(struct gribtable_s *p, unsigned char
     int discipline, center, mastertab, localtab, parmcat, parmnum;
     int use_local_table;
     static int count = 0;
+    struct gribtable_s *p_orig;
 
     if (p == NULL) return NULL;
 
@@ -162,8 +163,7 @@ static struct gribtable_s *search_gribtable(struct gribtable_s *p, unsigned char
 	|| (discipline >= 192 && discipline <= 254) ) use_local_table = 1;
    
     if (use_local_table == 1 && localtab == 0) {
-	if (count++ < 6 ) fprintf(stderr,"**** ERROR: local table = 0 is not allowed, set to 1 ***\n");
-	localtab = 1;
+	if (count++ < 6) fprintf(stderr,"**** WARNING: local table = 0 is not allowed, will try fallback value 1 as well ***\n");
     }
     if (use_local_table == 1 && localtab == 255) {
 	fatal_error("local gribtable is undefined (255)","");
@@ -179,12 +179,21 @@ static struct gribtable_s *search_gribtable(struct gribtable_s *p, unsigned char
     }
     else {
 //	printf(">> cname local find: disc %d center %d localtab %d pcat %d pnum %d\n", discipline, center, localtab, parmcat, parmnum);
+        p_orig = p;
+	/* look for entry with original localtab value as derived from grib message */
         for (; p->disc >= 0; p++) {
             if (discipline == p->disc && center == p->cntr && localtab == p->ltab && 
                 parmcat == p->pcat && parmnum == p->pnum) {
                 return p;
 	    }
 	}
+	/* fallback using localtab = 1 */
+	for (; p_orig->disc >= 0; p_orig++) {
+            if (discipline == p_orig->disc && center == p_orig->cntr && 1 == p_orig->ltab &&
+                parmcat == p_orig->pcat && parmnum == p_orig->pnum) {
+                return p_orig;
+            }
+        }
     }
     return NULL;
 }


### PR DESCRIPTION
Some (non-NCEP) grib messages have an illegal local-table flag, i.e. they report
localtab=0 even if some parameter category, discipline or number value have a setting > 192 which indicates "Reserved for local use". This results in error messages like
"**** ERROR: local table = 0 is not allowed, set to 1 ***".

Up to now, wgrib2 forcibly set localtab=1 in such cases and looks for gribtable entries with localtab=1.

However, when using the wgrib2 option "-gribtable_used" on such a grib message, an illegal gribtable is produced which can not be used as a custom, user-defined gribtable (by setting "export GRIB2TABLE=...").

As "-gribtable_used" is both used to dump/document parameter values as found in the grib message and as a template for a custom user gribtable, the illegal state of the table is retained.
Instead, the table lookup is relaxed by adding a fallback pass with corrected localtab setting. In the first pass, an entry is searched having the original, maybe illegal, localtab setting. If no entry is found, then a second search pass is made looking for localtab=1 entries.

Tone down the error message to a warning message.