### PR TITLE
Fix include file order

### DIFF
--- a/wgrib2/Config.c
+++ b/wgrib2/Config.c
@@ -3,8 +3,8 @@
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>
-#include "wgrib2.h"
 #include "grb2.h"
+#include "wgrib2.h"
 #include "fnlist.h"
 
 #if defined USE_NETCDF

--- a/wgrib2/Grib.c
+++ b/wgrib2/Grib.c
@@ -4,11 +4,12 @@
 #include <math.h>
 #include <limits.h>
 #include "grb2.h"
+#include "wgrib2.h"
+#include "fnlist.h"
+
 #ifdef USE_G2CLIB_LOW
 #include <grib2.h>
 #endif
-#include "wgrib2.h"
-#include "fnlist.h"
 
 /*
  * Grib_out

--- a/wgrib2/cname.c
+++ b/wgrib2/cname.c
@@ -2,8 +2,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "wgrib2.h"
 #include "grb2.h"
+#include "wgrib2.h"
 
 extern struct gribtable_s NCEP_gribtable[], ECMWF_gribtable[], DWD1_gribtable[], local_gribtable[];
 extern struct gribtable_s *user_gribtable;

--- a/wgrib2/ffopen.c
+++ b/wgrib2/ffopen.c
@@ -1,14 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "wgrib2.h"
 
 #ifndef DISABLE_STAT
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
-
-#include "wgrib2.h"
 
 /*
  * a simple extension to fopen

--- a/wgrib2/grid_ident.c
+++ b/wgrib2/grid_ident.c
@@ -6,8 +6,8 @@
  */
 
 #include <stdio.h>
-#include "wgrib2.h"
 #include "grb2.h"
+#include "wgrib2.h"
 #include "grid_id.h"
 
 /*

--- a/wgrib2/rd_seq_grib.c
+++ b/wgrib2/rd_seq_grib.c
@@ -5,6 +5,9 @@
 #include <math.h>
 #include <float.h>
 
+#include "grb2.h"
+#include "wgrib2.h"
+
 /* rd_seq_grib.c   10/2024   Public Domain Wesley Ebisuzaki
  *
  * two ways to read a grib file
@@ -27,9 +30,6 @@
 #include <unistd.h>
 #include <fcntl.h>
 #endif
-
-#include "grb2.h"
-#include "wgrib2.h"
 
 /*
  * rd_grib2_msg_seq_file.c *                              Wesley Ebisuzaki

--- a/wgrib2/unpk.c
+++ b/wgrib2/unpk.c
@@ -9,8 +9,8 @@
 #include <string.h>
 #include <stddef.h>
 
-#include "wgrib2.h"
 #include "grb2.h"
+#include "wgrib2.h"
 
 #ifdef USE_G2CLIB_LOW
     #include <grib2.h>

--- a/wgrib2/wgrib2.h
+++ b/wgrib2/wgrib2.h
@@ -37,10 +37,6 @@
 #endif
 #endif
 
-/* parameters to PNG encode routine */
-#define PNG_WIDTH_MAX  100000000
-#define PNG_HEIGHT_MAX 100000
-
 
 /*  1/2007 M. Schwarb unsigned int ndata */
 
@@ -518,10 +514,7 @@ int wrt_sec(unsigned const char *sec0, unsigned const char *sec1, unsigned const
 int scaling(unsigned char **sec, double *base, int *decimal, int *binary, int *nbits);
 unsigned char *mk_bms(float *data, unsigned int *ndata);
 
-int g2c_dec_png(unsigned char *pngbuf, int *width, int *height, unsigned char *cout);
 int ieee_grib_out(unsigned char **sec, float *data, unsigned int ndata, struct seq_file *out);
-int jpeg_grib_out(unsigned char **sec, float *data, unsigned int ndata, 
-    int nx, int ny, int use_scale, int dec_scale, int bin_scale, FILE *out);
 int jpeg2000_grib_out(unsigned char **sec, float *data, unsigned int ndata, int nx, int ny, 
     int use_scale, int dec_scale, int bin_scale, int wanted_bits, int max_bits, struct seq_file *out);
 int aec_grib_out(unsigned char ** sec, float *data, unsigned int ndata, int use_scale, int dec_scale, 


### PR DESCRIPTION
Fixes #390

`wgrib2.h` includes `config.h` which is needed for conditional compilation of features.

So statements like
```
#ifdef USE_G2CLIB_LOW
#include <grib2.h>
#endif
```
need to come after the inclusion of `wgrib2.h`
The files Grib.c, ffopen.c and rd_seq_grib.c are affected by this.

Fix include order and do some minor cleanup.