### PR TITLE
More doxygen

### DIFF
--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -483,9 +483,7 @@ static int write_ave_var(struct ave_var_struct *save) {
  * 
  * The options and expected sequence of fields is the same as with the -ave option. 
  * 
- * @param ARG2 ARG2 Arguments and context for the wgrib2 function macro. Requires two arguments:
- * - arg1: A string specifying the time interval and unit (e.g., "6hr", "1dy").
- * - arg2: The output file name where the results will be written.
+ * @param ARG2 ???
  * 
  * @return 0 for success, error code otherwise.
  * 

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -25,10 +25,10 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/** Flag to indicate decoding mode. */
+/** Decode grib file flag. */
 extern int decode;
 
-/** Flag to indicate file append mode. */
+/** Append grib file flag. */
 extern int file_append;
 
 /** Number of grid points in the x direction. */

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -55,13 +55,13 @@ extern int dec_scale;
 /** Flag to indicate the binary scale. */
 extern int bin_scale;
 
-/** Flag to indicate the number of bits wanted. */
+/** Number of bits wanted. */
 extern int wanted_bits;
 
-/** Flag to indicate the maximum number of bits. */
+/** Maximum number of bits. */
 extern int max_bits;
 
-/** Flag to indicate the output GRIB type. */
+/** Output GRIB type. */
 extern enum output_grib_type grib_type;
 
 /** Structure to hold average calculation data. */

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -40,19 +40,19 @@ extern int ny;
 /** Flag to indicate whether to save translation information. */
 extern int save_translation;
 
-/** Flag to indicate whether to flush output buffers. */
+/** Flush of output flag. */
 extern int flush_mode;
 
 /** Pointer to the translation array. */
 extern unsigned int *translation;
 
-/** Flag to indicate whether to use scaling. */
+/** Use scaling flag. */
 extern int use_scale;
 
-/** Flag to indicate the decoding scale. */
+/** Decoding scale flag. */
 extern int dec_scale;
 
-/** Flag to indicate the binary scale. */
+/** Binary scale flag. */
 extern int bin_scale;
 
 /** Number of bits wanted. */

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -1,3 +1,21 @@
+/** @file
+ * @brief Computes the mean and variance using the Welford method (one-pass):
+ * http://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance/
+ * 
+ * Based on Ave_test.c
+ * 
+ * @note variance(samples):
+ *   M := 0
+ *   S := 0
+ *   for k from 1 to N:
+ *     x := samples[k]
+ *     oldM := M
+ *     M := M + (x-M)/k
+ *     S := S + (x-M)*(x-oldM)
+ * return S/(N-1)
+ *
+ * @author Public Domain: Wesley Ebisuzaki @date 12/2016
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -7,53 +25,71 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/*
- * ave_var
- *
- *  v 0.1
- *
- * 12/2016: Public Domain: Wesley Ebisuzaki
- *         based on Ave_test.c public domain (Wesley Ebisuzaki)
- *
- * ave_var, computes the mean and variance using the Welford method (one-pass)
- */
+/** Flag to indicate decoding mode. */
+extern int decode;
 
-/*  from http://jonisalonen.com/2013/deriving-welfords-method-for-computing-variance/
+/** Flag to indicate file append mode. */
+extern int file_append;
 
-variance(samples):
-  M := 0
-  S := 0
-  for k from 1 to N:
-    x := samples[k]
-    oldM := M
-    M := M + (x-M)/k
-    S := S + (x-M)*(x-oldM)
-  return S/(N-1)
+/** Number of grid points in the x direction. */
+extern int nx;
 
- */
+/** Number of grid points in the y direction. */
+extern int ny;
 
-// #define DEBUG
+/** Flag to indicate whether to save translation information. */
+extern int save_translation;
 
-extern int decode, file_append, nx, ny, save_translation;
+/** Flag to indicate whether to flush output buffers. */
 extern int flush_mode;
+
+/** Pointer to the translation array. */
 extern unsigned int *translation;
-extern int use_scale, dec_scale, bin_scale, wanted_bits, max_bits;
+
+/** Flag to indicate whether to use scaling. */
+extern int use_scale;
+
+/** Flag to indicate the decoding scale. */
+extern int dec_scale;
+
+/** Flag to indicate the binary scale. */
+extern int bin_scale;
+
+/** Flag to indicate the number of bits wanted. */
+extern int wanted_bits;
+
+/** Flag to indicate the maximum number of bits. */
+extern int max_bits;
+
+/** Flag to indicate the output GRIB type. */
 extern enum output_grib_type grib_type;
 
+/** Structure to hold average calculation data. */
 struct ave_var_struct {
-    double *M, *S;
-    float *min, *max;
-    unsigned int ndata;
-
-    struct full_date time0, time1, time2; // time2 = verf time
-
-    int has_val, n_fields, n_missing;
-    int dt, dt_unit, nx, ny;
-    unsigned char *first_sec[9];
-    unsigned char *next_sec[9];
-    int use_scale, dec_scale, bin_scale, wanted_bits, max_bits;
-    enum output_grib_type grib_type;
-    struct seq_file out;
+    double *M; /**< Mean values. */
+    double *S; /**< Variance values. */
+    float *min; /**< Minimum values. */
+    float *max; /**< Maximum values. */
+    unsigned int ndata; /**< Number of data points. */
+    struct full_date time0; /**< Lowest reference time. */
+    struct full_date time1; /**< Current reference time. */
+    struct full_date time2; /**< Verification time. */
+    int has_val; /**< Flag to indicate if values are present. */
+    int n_fields; /**< Number of fields processed. */
+    int n_missing; /**< Number of missing values. */
+    int dt; /**< Time step in seconds. */
+    int dt_unit; /**< Time unit for the time step. */
+    int nx; /**< Number of grid points in the x direction. */
+    int ny; /**< Number of grid points in the y direction. */
+    unsigned char *first_sec[9]; /**< First section data. */
+    unsigned char *next_sec[9]; /**< Next section data. */
+    int use_scale; /**< Flag to indicate whether to use scaling. */
+    int dec_scale; /**< Flag to indicate the decoding scale. */
+    int bin_scale; /**< Flag to indicate the binary scale. */
+    int wanted_bits; /**< Flag to indicate the number of bits wanted. */
+    int max_bits; /**< Flag to indicate the maximum number of bits. */
+    enum output_grib_type grib_type; /**< Flag to indicate the output GRIB type. */
+    struct seq_file out; /**< Output sequence file. */
 };
 
 static int write_ave_var(struct ave_var_struct *save);
@@ -61,7 +97,15 @@ static int free_ave_var_struct(struct ave_var_struct *save);
 static int init_ave_var_struct(struct ave_var_struct *save, unsigned int ndata);
 static int update_ave_var_struct(struct ave_var_struct *save, unsigned char **sec, float *data, unsigned int ndata,int missing);
 
-
+/**
+ * Frees the memory allocated for the ave_var_struct.
+ * 
+ * @param save Pointer to the ave_var_struct to be freed.
+ * 
+ * @return 0 on success
+ * 
+ * @author Wesley Ebisuzaki @date 12/2016
+*/
 static int free_ave_var_struct(struct ave_var_struct *save) {
     if (save->has_val == 1) {
         free(save->M);
@@ -75,6 +119,16 @@ static int free_ave_var_struct(struct ave_var_struct *save) {
     return 0;
 }
 
+/** 
+ * Initializes the ave_var_struct with the given number of data points.
+ * 
+ * @param save Pointer to the ave_var_struct.
+ * @param ndata Number of data points.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @author Wesley Ebisuzaki @date 12/2016
+*/
 static int init_ave_var_struct(struct ave_var_struct *save, unsigned int ndata) {
     unsigned int i;
 
@@ -109,6 +163,19 @@ static int init_ave_var_struct(struct ave_var_struct *save, unsigned int ndata) 
     return 0;
 }
 
+/** 
+ * Updates the ave_var_struct with new data.
+ * 
+ * @param save Pointer to the ave_var_struct.
+ * @param sec Pointer to the section data.
+ * @param data Pointer to the data array.
+ * @param ndata Number of data points.
+ * @param missing Number of missing values.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @author Wesley Ebisuzaki @date 12/2016
+ */
 static int update_ave_var_struct(struct ave_var_struct *save, unsigned char **sec, float *data, unsigned int ndata,int missing) {
 
     unsigned int i, ii;
@@ -177,6 +244,15 @@ static int update_ave_var_struct(struct ave_var_struct *save, unsigned char **se
     return 0;
 }
 
+/** 
+ * Writes the average and variance data to a GRIB file.
+ * 
+ * @param save Pointer to the ave_var_struct.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @author Wesley Ebisuzaki @date 12/2016
+ */
 static int write_ave_var(struct ave_var_struct *save) {
     int j, n, pdt, i_ave;
     unsigned int i, ndata;
@@ -399,6 +475,32 @@ static int write_ave_var(struct ave_var_struct *save) {
 
 /*
  * HEADER:000:ave_var:output:2:average/std dev/min/max X=time step, Y=output
+ */
+
+/**
+ * Computes the mean, standard deviation, minimum, and maximum for each grid point 
+ * and writes the results to a specified output file.
+ * 
+ * The options and expected sequence of fields is the same as with the -ave option. 
+ * 
+ * @param ARG2 ARG2 Arguments and context for the wgrib2 function macro. Requires two arguments:
+ * - arg1: A string specifying the time interval and unit (e.g., "6hr", "1dy").
+ * - arg2: The output file name where the results will be written.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @note Welford's method for computing the mean and variance was used because it is a 
+ * one-pass scheme with the accuracy of a two-pass algorithm. 
+ * 
+ * ## Usage:
+ * -ave_var (time interval)  (output grib file)
+ *      time interval = (integer)(units)
+ *      (units) = hr, dy, mo, yr
+ * 
+ * ## Example: 
+ * ???
+ * 
+ * @author Wesley Ebisuzaki @date 12/2016
  */
 int f_ave_var(ARG2) {
 

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -49,10 +49,10 @@ extern unsigned int *translation;
 /** Use scaling flag. */
 extern int use_scale;
 
-/** Decoding scale flag. */
+/** Decimal scaling. */
 extern int dec_scale;
 
-/** Binary scale flag. */
+/** Binary scaling. */
 extern int bin_scale;
 
 /** Number of bits wanted. */

--- a/wgrib2/Ave_var.c
+++ b/wgrib2/Ave_var.c
@@ -483,17 +483,18 @@ static int write_ave_var(struct ave_var_struct *save) {
  * 
  * The options and expected sequence of fields is the same as with the -ave option. 
  * 
+ * ## Usage
+ * -ave_var (time interval)  (output grib file)
+ * 
+ * The time interval is the delta time for averaging in the form (integer)(units) 
+ * (e.g., "6hr", "1dy"). Units are hr, dy, mo, yr.
+ * 
  * @param ARG2 ???
  * 
  * @return 0 for success, error code otherwise.
  * 
  * @note Welford's method for computing the mean and variance was used because it is a 
  * one-pass scheme with the accuracy of a two-pass algorithm. 
- * 
- * ## Usage:
- * -ave_var (time interval)  (output grib file)
- *      time interval = (integer)(units)
- *      (units) = hr, dy, mo, yr
  * 
  * ## Example: 
  * ???

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -111,16 +111,16 @@ static int get_cindex (int i, int nx) {
  * Takes a rectangular box of data from a rectangular grid and writes it out in either text, bin, 
  * or spread (sheet) format. The extracted box can have every point or every n-th point. 
  * 
- * @param ARG4 Arguments and context for the wgrib2 function macro. Requires four arguments:
- * - arg1: A string specifying the x-dimension (e.g., "i1:i2:di").
- * - arg2: A string specifying the y-dimension (e.g., "j1:j2:dj").
- * - arg3: The output file name where the results will be written.
- * - arg4: The format to write the data in (e.g., "bin", "text", "spread").
+ * @param ARG4 ???
  * 
  * @return 0 for success, error code otherwise.
  * 
  * ##Usage:
  * -ijbox i1:i2:di j1:j2:dj output_file format
+ * 
+ * i1:i2:di specifies the x-dimension
+ * j1:j2:dj specifies the y-dimension
+ * output_file is written in the specified format (e.g., "bin", "text", "spread").
  * 
  * ## Example: 
  * ???

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -42,13 +42,13 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/** Flag to indicate decoding mode. */
+/** Decode grib file flag. */
 extern int decode;
 
-/** Flag to indicate flushing mode. */
+/** Flush of output flag. */
 extern int flush_mode;
 
-/** Flag to indicate file append mode. */
+/** Append grib file flag. */
 extern int file_append;
 
 /** Number of grid points in the x direction. */
@@ -57,10 +57,10 @@ extern int nx;
 /** Number of grid points in the y direction. */
 extern int ny;
 
-/** Flag to indicate GDS change number. */
+/** GDS change number flag. */
 extern int GDS_change_no;
 
-/** Flag to indicate scan mode. */
+/** Scan mode flag. */
 extern int scan;
 
 /** File header flag. */

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -87,9 +87,6 @@ struct Bbox {
     int last_GDS_change_no; /**< Last GDS change number. */
 };
 
-/* return c-style index, with wrapping; on input i is a fortran-style
-   index and nx is the */
-
 /**
  * Get the C-style index with wrapping.
  * 

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -57,7 +57,7 @@ extern int nx;
 /** Number of grid points in the y direction. */
 extern int ny;
 
-/** GDS change number flag. */
+/** GDS change number. */
 extern int GDS_change_no;
 
 /** Scan mode flag. */

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -1,3 +1,16 @@
+/**
+ * @file
+ * @brief Take a rectangular box of data from a rectangular grid and 
+ * write it to a file.
+ * @author Arlindo da Silva @date 3/2008
+ * 
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 3/2008 | A. da Silva | Initial
+ * 1/2011 | W. Ebisuzaki | replace new_GDS by GDS_change_no, WNE
+ */
+
 /*
 
     Copyright (C) 2008 by Arlindo da Silva <dasilva@opengrads.org>
@@ -29,31 +42,62 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/*
- * 3/2008 values inside index-space bounding box; based on Lola.c
- * 1/2011 replace new_GDS by GDS_change_no, WNE
- */
+/** Flag to indicate decoding mode. */
+extern int decode;
 
-extern int decode, flush_mode;
+/** Flag to indicate flushing mode. */
+extern int flush_mode;
+
+/** Flag to indicate file append mode. */
 extern int file_append;
 
-extern int nx, ny, GDS_change_no, scan;
+/** Number of grid points in the x direction. */
+extern int nx;
 
+/** Number of grid points in the y direction. */
+extern int ny;
+
+/** Flag to indicate GDS change number. */
+extern int GDS_change_no;
+
+/** Flag to indicate scan mode. */
+extern int scan;
+
+/** File header flag. */
 extern int header;
+
+/** Pointer to text format. */
 extern char *text_format;
+
+/** Number of columns in text output. */
 extern int text_column;
 
+/** Struct to hold bounding box information. */
 struct Bbox {
-    FILE *out;
-    int i1, i2, di, ni;
-    int j1, j2, dj, nj;
-    int *iptr;
-    int last_GDS_change_no;
+    FILE *out; /**< Output file pointer. */
+    int i1; /**< Starting index in the x direction. */
+    int i2; /**< Ending index in the x direction. */
+    int di; /**< Increment in the x direction. */
+    int ni; /**< Number of grid points in the x direction. */
+    int j1; /**< Starting index in the y direction. */
+    int j2; /**< Ending index in the y direction. */
+    int dj; /**< Increment in the y direction. */
+    int nj; /**< Number of grid points in the y direction. */
+    int *iptr; /**< Pointer to the grid data. */
+    int last_GDS_change_no; /**< Last GDS change number. */
 };
 
 /* return c-style index, with wrapping; on input i is a fortran-style
    index and nx is the */
 
+/**
+ * Get the C-style index with wrapping.
+ * 
+ * @param i Index in Fortran-style (1-offset).
+ * @param nx Number of grid points in the x direction.
+ * 
+ * @return C index
+ */
 static int get_cindex (int i, int nx) { 
     int j;
     j = (i - 1) % nx;
@@ -66,6 +110,26 @@ static int get_cindex (int i, int nx) {
  * HEADER:100:ijbox:output:4:grid values in bounding box  X=i1:i2[:di] Y=j1:j2[:dj] Z=file A=[bin|text|spread]
  */
 
+/**
+ * Takes a rectangular box of data from a rectangular grid and writes it out in either text, bin, 
+ * or spread (sheet) format. The extracted box can have every point or every n-th point. 
+ * 
+ * @param ARG4 Arguments and context for the wgrib2 function macro. Requires four arguments:
+ * - arg1: A string specifying the x-dimension (e.g., "i1:i2:di").
+ * - arg2: A string specifying the y-dimension (e.g., "j1:j2:dj").
+ * - arg3: The output file name where the results will be written.
+ * - arg4: The format to write the data in (e.g., "bin", "text", "spread").
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * ##Usage:
+ * -ijbox i1:i2:di j1:j2:dj output_file format
+ * 
+ * ## Example: 
+ * ???
+ * 
+ * @author Arlindo da Silva @date 3/2008
+ */
 int f_ijbox(ARG4) {
 
     int i1, i2, di, ni;

--- a/wgrib2/Bbox.c
+++ b/wgrib2/Bbox.c
@@ -111,16 +111,16 @@ static int get_cindex (int i, int nx) {
  * Takes a rectangular box of data from a rectangular grid and writes it out in either text, bin, 
  * or spread (sheet) format. The extracted box can have every point or every n-th point. 
  * 
+ * ## Usage
+ * -ijbox i1:i2:di j1:j2:dj output_file format
+ * 
+ * i1:i2:di specifies the x-dimension, where i1 is the starting index, i2 is the ending index, and di is the increment.
+ * j1:j2:dj specifies the y-dimension, where j1 is the starting index, j2 is the ending index, and dj is the increment.
+ * output_file is written in the specified format (e.g., "bin", "text", "spread").
+ * 
  * @param ARG4 ???
  * 
  * @return 0 for success, error code otherwise.
- * 
- * ##Usage:
- * -ijbox i1:i2:di j1:j2:dj output_file format
- * 
- * i1:i2:di specifies the x-dimension
- * j1:j2:dj specifies the y-dimension
- * output_file is written in the specified format (e.g., "bin", "text", "spread").
  * 
  * ## Example: 
  * ???

--- a/wgrib2/Box_ave.c
+++ b/wgrib2/Box_ave.c
@@ -35,16 +35,16 @@
  *             
  */
 
-/** Flag to indicate decoding mode. */
+/** Decode grib file flag. */
 extern int decode;
 
-/** Flag to indicate file append mode. */
+/** Append grib file flag. */
 extern int file_append;
 
 /** Flag to indicate whether to save translation information. */
 extern int save_translation;
 
-/** Flag to indicate scan mode. */
+/** Scan mode flag. */
 extern int scan;
 
 /** Number of grid points in the x-direction. */

--- a/wgrib2/Box_ave.c
+++ b/wgrib2/Box_ave.c
@@ -62,10 +62,7 @@ extern unsigned int ny_;
  * Amount of smoothing can be controlled by the size of the box. Can be used on regional
  * and global fields. To identify global fields, you can use the option -cyclic.
  * 
- * @param ARG3 Arguments and context for the wgrib2 function macro. Requires three arguments:
- * - arg1: Size of the box in the x-direction (must be an odd integer).
- * - arg2: Size of the box in the y-direction (must be an odd integer).
- * - arg3: Critical weight for averaging. If set to -1, all defined values are averaged.
+ * @param ARG3 ???
  * 
  * @return 0 for success, error code otherwise.
  * 

--- a/wgrib2/Box_ave.c
+++ b/wgrib2/Box_ave.c
@@ -1,3 +1,8 @@
+/** @file
+ * @brief Smoothing of a field by doing a box average
+ * @author Public Domain: Wesley Ebisuzaki @date 3/2018
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -30,14 +35,63 @@
  *             
  */
 
+/** Flag to indicate decoding mode. */
+extern int decode;
+
+/** Flag to indicate file append mode. */
+extern int file_append;
+
+/** Flag to indicate whether to save translation information. */
+extern int save_translation;
+
+/** Flag to indicate scan mode. */
+extern int scan;
+
+/** Number of grid points in the x-direction. */
+extern unsigned int nx_;
+
+/** Number of grid points in the y-direction. */
+extern unsigned int ny_;
 
 /*
  * HEADER:000:box_ave:misc:3:box average X=odd integer (lon) Y=odd integer (lat) critical_weight
  */
 
-extern int decode, file_append, save_translation, scan;
-extern unsigned int nx_, ny_;
-
+/**
+ * Does a spatial smoothing by doing a simple box average of the data field.
+ * Amount of smoothing can be controlled by the size of the box. Can be used on regional
+ * and global fields. To identify global fields, you can use the option -cyclic.
+ * 
+ * @param ARG3 Arguments and context for the wgrib2 function macro. Requires three arguments:
+ * - arg1: Size of the box in the x-direction (must be an odd integer).
+ * - arg2: Size of the box in the y-direction (must be an odd integer).
+ * - arg3: Critical weight for averaging. If set to -1, all defined values are averaged.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @note The speed of -box_ave is O(NX*NY*DY). The O(NX*NY) method was slower because of 
+ * poor cache utilization and false sharing.
+ * 
+ * ##Usage:
+ * -box_ave DX DY CRITICAL_WEIGHT
+ * 
+ * DX=width of box (in grid points), DX has to be an odd positive integer
+ * DY=height of box (in grid points), DY has to be an odd positive integer
+ * 
+ * The box average is the mean value for a box of DX x DY centered on the grid point.
+ *
+ * CRITICAL_WEIGHT
+ *    -1: grid(i,j) = UNDEFINED    if original grid(i,j) is undefined
+ *                    = box average  if original grid(i,j) is defined
+ *    not -1: let wt = number of grid points that are defined in the box
+ *        grid(i,j) = UNDEFINED     if wt <= WT
+ *          = box average   if wt > WT
+ * 
+ * ## Example:
+ * ???
+ * 
+ * @author Wesley Ebisuzaki @date 3/2018
+ */
 int f_box_ave(ARG3) {
 
     unsigned int i,j,k, j0, j1, m;

--- a/wgrib2/Box_ave.c
+++ b/wgrib2/Box_ave.c
@@ -62,14 +62,7 @@ extern unsigned int ny_;
  * Amount of smoothing can be controlled by the size of the box. Can be used on regional
  * and global fields. To identify global fields, you can use the option -cyclic.
  * 
- * @param ARG3 ???
- * 
- * @return 0 for success, error code otherwise.
- * 
- * @note The speed of -box_ave is O(NX*NY*DY). The O(NX*NY) method was slower because of 
- * poor cache utilization and false sharing.
- * 
- * ##Usage:
+ * ## Usage
  * -box_ave DX DY CRITICAL_WEIGHT
  * 
  * DX=width of box (in grid points), DX has to be an odd positive integer
@@ -83,6 +76,13 @@ extern unsigned int ny_;
  *    not -1: let wt = number of grid points that are defined in the box
  *        grid(i,j) = UNDEFINED     if wt <= WT
  *          = box average   if wt > WT
+ * 
+ * @param ARG3 ???
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @note The speed of -box_ave is O(NX*NY*DY). The O(NX*NY) method was slower because of 
+ * poor cache utilization and false sharing.
  * 
  * ## Example:
  * ???

--- a/wgrib2/Check_pdt_size.c
+++ b/wgrib2/Check_pdt_size.c
@@ -42,8 +42,7 @@ int warn_check_pdt = 1;
  * 
  * You may skip this check by using the -check_pdt_size 0 option.
  * 
- * @param ARG1 Arguments and context for the wgrib2 function macro. Requires a single 
- * argument which is 0 or 1 to disable or enable the check.
+ * @param ARG1 ???
  * 
  * @return 0 for success.
  * 

--- a/wgrib2/Check_pdt_size.c
+++ b/wgrib2/Check_pdt_size.c
@@ -26,7 +26,7 @@
  * HEADER:100:check_pdt_size:misc:1:check pdt size X=1 enable/default, X=0 disable
  */
 
- /** Flag to indicate whether to check PDT size. */
+/** Flag to indicate whether to check PDT size. */
 int check_pdt_size_flag = 1;
 
 /** Flag to indicate whether to issue warnings for PDT size checks. */
@@ -42,17 +42,18 @@ int warn_check_pdt = 1;
  * 
  * You may skip this check by using the -check_pdt_size 0 option.
  * 
+ * ## Usage
+ * -check_pdt_size X
+ *
+ * Where X is 0 (disable) or 1 (enable, default).
+ * 
  * @param ARG1 ???
  * 
  * @return 0 for success.
  * 
- * @note In theory, the pdt can be bigger than expected with no ill consequences,
- *  however, if the pdt is smaller than expectations, then any routine that
- *  uses the pdt could be reading outside of the pdt.
- * 
- * ## Usage:
- * - check_pdt_size     0 (disable)
- *                      1 (enable, default)
+ * @note In theory, the pdt can be bigger than expected with no ill consequences, 
+ * however, if the pdt is smaller than expectations, then any routine that uses the 
+ * pdt could be reading outside of the pdt.
  * 
  * @author Wesley Ebisuzaki @date 09/2020
  */

--- a/wgrib2/Check_pdt_size.c
+++ b/wgrib2/Check_pdt_size.c
@@ -1,3 +1,8 @@
+/** @file
+ * @brief Check the size of the Product Definition Template (PDT, Section 4).
+ * @author Public Domain: Wesley Ebisuzaki @date 09/2020
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "grb2.h"
@@ -21,14 +26,51 @@
  * HEADER:100:check_pdt_size:misc:1:check pdt size X=1 enable/default, X=0 disable
  */
 
+ /** Flag to indicate whether to check PDT size. */
 int check_pdt_size_flag = 1;
+
+/** Flag to indicate whether to issue warnings for PDT size checks. */
 int warn_check_pdt = 1;
 
+/**
+ * Function to set the check_pdt_size_flag.
+ * 
+ * If the PDT is wrong size, wgrib2 will exit with a delayed fatal error. 
+ * The fatal error is delayed so the user can investigate the contents of the 
+ * bad grib message. Note that it is possible to seg fault because Section 4 is a 
+ * different size than expected, and the rest of the grib message may be corrupted. 
+ * 
+ * You may skip this check by using the -check_pdt_size 0 option.
+ * 
+ * @param ARG1 Arguments and context for the wgrib2 function macro. Requires a single 
+ * argument which is 0 or 1 to disable or enable the check.
+ * 
+ * @return 0 for success.
+ * 
+ * @note In theory, the pdt can be bigger than expected with no ill consequences,
+ *  however, if the pdt is smaller than expectations, then any routine that
+ *  uses the pdt could be reading outside of the pdt.
+ * 
+ * ## Usage:
+ * - check_pdt_size     0 (disable)
+ *                      1 (enable, default)
+ * 
+ * @author Wesley Ebisuzaki @date 09/2020
+ */
 int f_check_pdt_size(ARG1) {
     check_pdt_size_flag = atoi(arg1);
     return 0;
 }
 
+/**
+ * Checks the size of the Product Definition Template (PDT) in the GRIB message.
+ * 
+ * @param sec Pointer to the GRIB message sections.
+ * 
+ * @return 0 for success, 1 if the PDT size is incorrect.
+ * 
+ * @author Wesley Ebisuzaki @date 09/2020
+ */
 int check_pdt_size(unsigned char **sec) {
     int calc_pdt_size, pdt_size;
 

--- a/wgrib2/Checksum.c
+++ b/wgrib2/Checksum.c
@@ -1,3 +1,10 @@
+/** @file
+ * @brief Calculate CRC32 checksum for sections and the whole message. The checksum
+ * algorithm is the same as the POSIX 'cksum' utility uses.
+ * @author Public Domain: R.N. Bokhorst, reinoud.bokhorst@bmtargoss.com 
+ * @date 06/2009
+ */
+
 /*
  * Checksum.c
  *   Calculate CRC32 checksum for sections and the whole message. The checksum
@@ -14,10 +21,40 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
+/** Flag to indicate decoding mode. */
 extern int decode;
 
 /*
  * HEADER:400:checksum:inv:1:CRC checksum of section X (0..8), whole message (X = -1/message) or (X=data)
+ */
+
+/**
+ * Writes the checksum (32 bit CRC) for the entire grib message, the decoded grid-point 
+ * data or any specified section.
+ * 
+ * @param ARG1 Arguments and context for the wgrib2 function macro. 
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @note Two sections or messages with the same checksum are very probably the same. If the grid-point 
+ * data has the same checksum, they are very probably bitwise identical. This option can be used to check 
+ * the integrity of a grib message or to check for for identical sections. Note that decoded grid-point 
+ * values may not be unique. Wgrib2 is compiled with the "fast" option which may sacrifice some precision 
+ * for speed or uniqueness. For example, A*B*C should be calculated by (A*B)*C. However A*(B*C) will be faster 
+ * if B*C was previously calculated. While mathematically the expressions are the same, the final results may 
+ * be slightly different. 
+ * 
+ * ## Usage:
+ * -checksum N
+ * where N is:
+ *   -1: whole message
+ *   1-8: section number
+ *   data: grid-point data
+ * 
+ * ## Example:
+ * ???
+ * 
+ * @author R.N. Bokhorst @date 06/2009
  */
 int f_checksum(ARG1) {
     unsigned int crc;

--- a/wgrib2/Checksum.c
+++ b/wgrib2/Checksum.c
@@ -21,8 +21,9 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/** Flag to indicate decoding mode. */
+/** Decode grib file flag. */
 extern int decode;
+
 
 /*
  * HEADER:400:checksum:inv:1:CRC checksum of section X (0..8), whole message (X = -1/message) or (X=data)

--- a/wgrib2/Checksum.c
+++ b/wgrib2/Checksum.c
@@ -32,6 +32,14 @@ extern int decode;
  * Writes the checksum (32 bit CRC) for the entire grib message, the decoded grid-point 
  * data or any specified section.
  * 
+ * ## Usage
+ * -checksum N
+ * 
+ * Where N is:
+ *   -1: whole message
+ *   1-8: section number
+ *   data: grid-point data
+ * 
  * @param ARG1 ???
  * 
  * @return 0 for success, error code otherwise.
@@ -43,14 +51,6 @@ extern int decode;
  * for speed or uniqueness. For example, A*B*C should be calculated by (A*B)*C. However A*(B*C) will be faster 
  * if B*C was previously calculated. While mathematically the expressions are the same, the final results may 
  * be slightly different. 
- * 
- * ## Usage:
- * -checksum N
- * 
- * where N is:
- *   -1: whole message
- *   1-8: section number
- *   data: grid-point data
  * 
  * ## Example:
  * ???

--- a/wgrib2/Checksum.c
+++ b/wgrib2/Checksum.c
@@ -32,7 +32,7 @@ extern int decode;
  * Writes the checksum (32 bit CRC) for the entire grib message, the decoded grid-point 
  * data or any specified section.
  * 
- * @param ARG1 Arguments and context for the wgrib2 function macro. 
+ * @param ARG1 ???
  * 
  * @return 0 for success, error code otherwise.
  * 
@@ -46,6 +46,7 @@ extern int decode;
  * 
  * ## Usage:
  * -checksum N
+ * 
  * where N is:
  *   -1: whole message
  *   1-8: section number

--- a/wgrib2/Checksum.c
+++ b/wgrib2/Checksum.c
@@ -24,7 +24,6 @@
 /** Decode grib file flag. */
 extern int decode;
 
-
 /*
  * HEADER:400:checksum:inv:1:CRC checksum of section X (0..8), whole message (X = -1/message) or (X=data)
  */

--- a/wgrib2/Cluster.c
+++ b/wgrib2/Cluster.c
@@ -1,3 +1,8 @@
+/** @file
+ * @brief Options for showing cluster information.
+ * @author Public Domain: Wesley Ebisuzaki 
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -5,16 +10,22 @@
 #include "wgrib2.h"
 #include "fnlist.h"
 
-/* Cluster.c    10/2024  Public Domain  Wesley Ebisuzaki
- *
- * options for showing cluster information
- *
- */
-
 /*
  * HEADER:-1:cluster:inv:0:cluster identifier
  */
 
+/**
+ * Display the cluster identifier.
+ * 
+ * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * 
+ * @return 0 for success, does not return an error code.
+ * 
+ * ## Usage:
+ * -cluster
+ * 
+ * @author Wesley Ebisuzaki
+ */
 int f_cluster(ARG0) {
     int i;
 
@@ -29,7 +40,18 @@ int f_cluster(ARG0) {
  * HEADER:-1:N_clusters:inv:0:number of clusters
  */
 
-
+/**
+ * Display the number of clusters.
+ * 
+ * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * 
+ * @return 0 for success, does not return an error code.
+ * 
+ * ## Usage:
+ * -N_clusters
+ * 
+ * @author Wesley Ebisuzaki
+ */
 int f_N_clusters(ARG0) {
     int i;
 
@@ -43,7 +65,23 @@ int f_N_clusters(ARG0) {
 /*
  * HEADER:-1:cluster_info:inv:0:cluster information
  */
+
+/** Newline character */
 extern char *nl;
+
+/**
+ * Display information about the cluster, including the cluster identifier,
+ * number of forecasts in the cluster, and other related data.
+ * 
+ * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * 
+ * @return 0 for success, does not return an error code.
+ * 
+ * ## Usage:
+ * -cluster_info
+ * 
+ * @author Wesley Ebisuzaki
+ */
 int f_cluster_info(ARG0) {
 
     unsigned char *nc, *cluster;

--- a/wgrib2/Cluster.c
+++ b/wgrib2/Cluster.c
@@ -1,6 +1,6 @@
 /** @file
  * @brief Options for showing cluster information.
- * @author Public Domain: Wesley Ebisuzaki 
+ * @author Public Domain: Wesley Ebisuzaki @date 2006
  */
 
 #include <stdio.h>
@@ -24,7 +24,7 @@
  * ## Usage:
  * -cluster
  * 
- * @author Wesley Ebisuzaki
+ * @author Wesley Ebisuzaki @date 2006
  */
 int f_cluster(ARG0) {
     int i;
@@ -50,7 +50,7 @@ int f_cluster(ARG0) {
  * ## Usage:
  * -N_clusters
  * 
- * @author Wesley Ebisuzaki
+ * @author Wesley Ebisuzaki @date 2006
  */
 int f_N_clusters(ARG0) {
     int i;
@@ -80,7 +80,7 @@ extern char *nl;
  * ## Usage:
  * -cluster_info
  * 
- * @author Wesley Ebisuzaki
+ * @author Wesley Ebisuzaki @date 2006
  */
 int f_cluster_info(ARG0) {
 

--- a/wgrib2/Cluster.c
+++ b/wgrib2/Cluster.c
@@ -17,13 +17,13 @@
 /**
  * Display the cluster identifier.
  * 
- * @param ARG0 ???
- * 
- * @return 0 for success, does not return an error code.
- * 
  * ## Usage:
  * -cluster
  * 
+ * @param ARG0 ???
+ * 
+ * @return 0 for success, does not return an error code.
+ *
  * @author Wesley Ebisuzaki @date 2006
  */
 int f_cluster(ARG0) {
@@ -43,13 +43,13 @@ int f_cluster(ARG0) {
 /**
  * Display the number of clusters.
  * 
- * @param ARG0 ???
- * 
- * @return 0 for success, does not return an error code.
- * 
  * ## Usage:
  * -N_clusters
  * 
+ * @param ARG0 ???
+ * 
+ * @return 0 for success, does not return an error code.
+ *
  * @author Wesley Ebisuzaki @date 2006
  */
 int f_N_clusters(ARG0) {
@@ -73,12 +73,12 @@ extern char *nl;
  * Display information about the cluster, including the cluster identifier,
  * number of forecasts in the cluster, and other related data.
  * 
+ * ## Usage:
+ * -cluster_info
+ * 
  * @param ARG0 ???
  * 
  * @return 0 for success, does not return an error code.
- * 
- * ## Usage:
- * -cluster_info
  * 
  * @author Wesley Ebisuzaki @date 2006
  */

--- a/wgrib2/Cluster.c
+++ b/wgrib2/Cluster.c
@@ -17,7 +17,7 @@
 /**
  * Display the cluster identifier.
  * 
- * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * @param ARG0 ???
  * 
  * @return 0 for success, does not return an error code.
  * 
@@ -43,7 +43,7 @@ int f_cluster(ARG0) {
 /**
  * Display the number of clusters.
  * 
- * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * @param ARG0 ???
  * 
  * @return 0 for success, does not return an error code.
  * 
@@ -73,7 +73,7 @@ extern char *nl;
  * Display information about the cluster, including the cluster identifier,
  * number of forecasts in the cluster, and other related data.
  * 
- * @param ARG0 Arguments and context for the wgrib2 function macro.
+ * @param ARG0 ???
  * 
  * @return 0 for success, does not return an error code.
  * 

--- a/wgrib2/bitstream.c
+++ b/wgrib2/bitstream.c
@@ -14,12 +14,11 @@ static unsigned int ones[]={0, 1,3,7,15, 31,63,127,255};
 /**
  * Reads a bitstream and converts it to an array of unsigned integers.
  * 
- * @param p Pointer to the start of the bitstream.
- * @param offset Bit offset to start reading from (0-7).
- * @param u Pointer to the output array of unsigned integers.
- * @param n_bits Number of bits to read for each integer. 
- * @param n Number of integers to read.
- *
+ * The function assumes that the bitstream starts on a byte boundary. 
+ * For 32-bit machines, n_bits should be less than or equal to 25.
+ * 
+ * bitstream (n_bits/uint) -> u[0..n-1]
+ * 
  * ### Program History Log
  * Date | Programmer | Comments
  * -----|------------|---------
@@ -27,11 +26,12 @@ static unsigned int ones[]={0, 1,3,7,15, 31,63,127,255};
  * 04/2022 | W. Ebisuzaki | limit to nbits is now 32 (32 bit integer), 
  *                          rd_bitstream_offset -> rd_bitstream
  * 
- * @note The function assumes that the bitstream starts on a byte boundary. 
- * For 32-bit machines, n_bits should be less than or equal to 25.
- * 
- * bitstream (n_bits/uint) -> u[0..n-1]
- * 
+ * @param p Pointer to the start of the bitstream.
+ * @param offset Bit offset to start reading from (0-7).
+ * @param u Pointer to the output array of unsigned integers.
+ * @param n_bits Number of bits to read for each integer. 
+ * @param n Number of integers to read.
+ *
  * @author Wesley Ebisuzaki @date 6/2009
  */
 void rd_bitstream(unsigned char *p, int offset, int *u, int n_bits, unsigned int n) {
@@ -88,18 +88,18 @@ void rd_bitstream(unsigned char *p, int offset, int *u, int n_bits, unsigned int
 /**
  * Reads a bitstream and converts it to an array of floats.
  * 
- * @param p Pointer to the start of the bitstream.
- * @param offset Bit offset to start reading from (0-7).
- * @param u Pointer to the output array of floats.
- * @param n_bits Number of bits to read for each float.
- * @param n Number of floats to read.
- * 
  * ### Program History Log
  * Date | Programmer | Comments
  * -----|------------|---------
  * 6/2009 | W. Ebisuzaki | Initial
  * 04/2022 | W. Ebisuzaki | limit to nbits is now 32 (32 bit integer), 
  *                          rd_bitstream_offset -> rd_bitstream
+ * 
+ * @param p Pointer to the start of the bitstream.
+ * @param offset Bit offset to start reading from (0-7).
+ * @param u Pointer to the output array of floats.
+ * @param n_bits Number of bits to read for each float.
+ * @param n Number of floats to read.
  * 
  * @author Wesley Ebisuzaki @date 6/2009
  */
@@ -168,10 +168,10 @@ static int n_bitstream;
 /** 
  * Write integer to the bitstream with a specified number of bits.
  * 
+ * Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
+ * 
  * @param t Integer to add to the bitstream.
  * @param n_bits Number of bits to represent the integer. Should be less than or equal to 25.
- * 
- * @note Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
  * 
  * @author Wesley Ebisuzaki @date 6/2009
 */
@@ -196,11 +196,11 @@ void add_bitstream(int t, int n_bits) {
 /**
  * Write multiple integers to the bitstream with a specified number of bits.
  * 
+ * Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
+ * 
  * @param t Pointer to the array of integers to add to the bitstream.
  * @param n Number of integers to write.
  * @param n_bits Number of bits to represent each integer. Should be less than or equal to 25.
- * 
- * @note Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
  * 
  * @author Wesley Ebisuzaki @date 6/2009
  */
@@ -264,10 +264,10 @@ void add_many_bitstream(int *t, unsigned int n, int n_bits) {
 /**
  * Initialize the bitstream with a given buffer.
  * 
- * @param new_bitstream Pointer to the buffer where the bitstream will be stored.
+ * This function should be called before adding any bits to the bitstream. To close the bitstream, 
+ * call finish_bitstream().
  * 
- * @note This function should be called before adding any bits to the bitstream. 
- * To close the bitstream, call finish_bitstream().
+ * @param new_bitstream Pointer to the buffer where the bitstream will be stored.
  * 
  * @author Wesley Ebisuzaki @date 6/2009
  */
@@ -280,7 +280,7 @@ void init_bitstream(unsigned char *new_bitstream) {
 /**
  * Close the bitstream by writing any remaining bits to the buffer. Last byte is zero packed.
  * 
- * @note This function should be called after all bits have been added to the bitstream.
+ * This function should be called after all bits have been added to the bitstream.
  * 
  * @author Wesley Ebisuzaki @date 6/2009
  */

--- a/wgrib2/bitstream.c
+++ b/wgrib2/bitstream.c
@@ -1,23 +1,39 @@
+/** @file
+ * @brief Bitstream handling functions for wgrib2.
+ * @author Public Domain: Wesley Ebisuzaki @date 6/2009
+ */
+
 #include <stdio.h>
 #include <stddef.h>
 #include <limits.h>
 #include "wgrib2.h"
 
-/* 6/2009 public domain 	wesley ebisuzaki
- *
- * code taken from wgrib 
- *
- *  takes a bitstream -> vector of unsigned ints
- *  bitstream starts on a byte boundary
- *  for 32 bit machine:  nbits <= 25
- *
- * bitstream (n_bits/uint) -> u[0..n-1]
- *
- * v1.1  limit to nbits is now 32 (32 bit integer), rd_bitstream_offset -> rd_bitstream
- */
-
+/** Array of masks for extracting bits */
 static unsigned int ones[]={0, 1,3,7,15, 31,63,127,255};
 
+/**
+ * Reads a bitstream and converts it to an array of unsigned integers.
+ * 
+ * @param p Pointer to the start of the bitstream.
+ * @param offset Bit offset to start reading from (0-7).
+ * @param u Pointer to the output array of unsigned integers.
+ * @param n_bits Number of bits to read for each integer. 
+ * @param n Number of integers to read.
+ *
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 6/2009 | W. Ebisuzaki | Initial
+ * 04/2022 | W. Ebisuzaki | limit to nbits is now 32 (32 bit integer), 
+ *                          rd_bitstream_offset -> rd_bitstream
+ * 
+ * @note The function assumes that the bitstream starts on a byte boundary. 
+ * For 32-bit machines, n_bits should be less than or equal to 25.
+ * 
+ * bitstream (n_bits/uint) -> u[0..n-1]
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
+ */
 void rd_bitstream(unsigned char *p, int offset, int *u, int n_bits, unsigned int n) {
 
     unsigned int tbits;
@@ -69,11 +85,24 @@ void rd_bitstream(unsigned char *p, int offset, int *u, int n_bits, unsigned int
     }
 }
 
-/*
- * void rd_bitstream_flt
- *   rd_bitstream_flt() is like rd_bitstream() except that returns a float instead of int
+/**
+ * Reads a bitstream and converts it to an array of floats.
+ * 
+ * @param p Pointer to the start of the bitstream.
+ * @param offset Bit offset to start reading from (0-7).
+ * @param u Pointer to the output array of floats.
+ * @param n_bits Number of bits to read for each float.
+ * @param n Number of floats to read.
+ * 
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 6/2009 | W. Ebisuzaki | Initial
+ * 04/2022 | W. Ebisuzaki | limit to nbits is now 32 (32 bit integer), 
+ *                          rd_bitstream_offset -> rd_bitstream
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
  */
-
 void rd_bitstream_flt(unsigned char *p, int offset, float *u, int n_bits, unsigned int n) {
 
     unsigned int tbits;
@@ -124,23 +153,28 @@ void rd_bitstream_flt(unsigned char *p, int offset, float *u, int n_bits, unsign
     }
 }
 
-/*
- * make a bitstream with variable length packing
- *
- * n_bits should be <= 25
- *
- * last byte is zero packed
- *
- * start: init_bitstream(buffer)
- *
- * to write: add_bitstream(data, number of bits to write)
- *
- * to close (zero fill):  finish_bitstream()
- */
-
+/** Pointer to bitstream. */
 static unsigned char *bitstream;
-static int rbits, reg, n_bitstream;
 
+/** Number of bits remaining in the current byte. */
+static int rbits;
+
+/** Bit accumulator for the current byte. */
+static int reg;
+
+/** Total number of bits written to the bitstream. */
+static int n_bitstream;
+
+/** 
+ * Write integer to the bitstream with a specified number of bits.
+ * 
+ * @param t Integer to add to the bitstream.
+ * @param n_bits Number of bits to represent the integer. Should be less than or equal to 25.
+ * 
+ * @note Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
+*/
 void add_bitstream(int t, int n_bits) {
     unsigned int jmask;
 
@@ -159,6 +193,17 @@ void add_bitstream(int t, int n_bits) {
     return;
 }
 
+/**
+ * Write multiple integers to the bitstream with a specified number of bits.
+ * 
+ * @param t Pointer to the array of integers to add to the bitstream.
+ * @param n Number of integers to write.
+ * @param n_bits Number of bits to represent each integer. Should be less than or equal to 25.
+ * 
+ * @note Bitstream is initialized with init_bitstream(). To close the bitstream, call finish_bitstream().
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
+ */
 void add_many_bitstream(int *t, unsigned int n, int n_bits) {
     unsigned int jmask, tt;
     unsigned int i;
@@ -215,12 +260,30 @@ void add_many_bitstream(int *t, unsigned int n, int n_bits) {
     }
     return;
 }
+
+/**
+ * Initialize the bitstream with a given buffer.
+ * 
+ * @param new_bitstream Pointer to the buffer where the bitstream will be stored.
+ * 
+ * @note This function should be called before adding any bits to the bitstream. 
+ * To close the bitstream, call finish_bitstream().
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
+ */
 void init_bitstream(unsigned char *new_bitstream) {
     bitstream = new_bitstream;
     n_bitstream = reg = rbits = 0;
     return;
 }
 
+/**
+ * Close the bitstream by writing any remaining bits to the buffer. Last byte is zero packed.
+ * 
+ * @note This function should be called after all bits have been added to the bitstream.
+ * 
+ * @author Wesley Ebisuzaki @date 6/2009
+ */
 void finish_bitstream(void) {
     if (rbits) {
         n_bitstream++;

--- a/wgrib2/cname.c
+++ b/wgrib2/cname.c
@@ -38,12 +38,6 @@ extern int tigge;
 /** TIGGE Grib Table */
 extern struct gribtable_s tigge_gribtable[];
 #endif
-/*
- * get the name information    2006 Public Domain  Wesley Ebisuzaki
- *
- * if inv_out, name, desc, unit == NULL, not used
-
- */
 
 /** Indicates the GRIB table name to use */
 extern int names;

--- a/wgrib2/cname.c
+++ b/wgrib2/cname.c
@@ -1,35 +1,70 @@
+/** @file
+ * @brief GRIB table names.
+ * @author Public Domain: Wesley Ebisuzaki @date 2006
+ * 
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2006 | W. Ebisuzaki | Initial
+ * 4/2007 | W. Ebisuzaki | Added netCDF support
+ * 6/2011 | W. Ebisuzaki | Made parameter category >= 192 local
+ * 2/2012 | W. Ebisuzaki | Fixed search_gribtab for local tables
+ * 4/2013 | W. Ebisuzaki | gribtab -> gribtable, added user_gribtable
+ * 1/2021 | W. Ebisuzaki | Use NCEP or ECMWF names as default, local table handled epar
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include "grb2.h"
 #include "wgrib2.h"
 
-extern struct gribtable_s NCEP_gribtable[], ECMWF_gribtable[], DWD1_gribtable[], local_gribtable[];
+/** NCEP Grib Table */
+extern struct gribtable_s NCEP_gribtable[];
+/** ECMWF Grib Table */
+extern struct gribtable_s ECMWF_gribtable[];
+/** DWD1 Grib Table */
+extern struct gribtable_s DWD1_gribtable[];
+/** Local Grib Table */
+extern struct gribtable_s local_gribtable[];
+/** User-defined Grib Table */
 extern struct gribtable_s *user_gribtable;
 
 static struct gribtable_s *search_gribtable(struct gribtable_s *gribtable, unsigned char **sec);
 
 #ifdef USE_TIGGE
+/** Flag to use TIGGE */
 extern int tigge;
+/** TIGGE Grib Table */
 extern struct gribtable_s tigge_gribtable[];
 #endif
 /*
  * get the name information    2006 Public Domain  Wesley Ebisuzaki
  *
  * if inv_out, name, desc, unit == NULL, not used
- *
- * v1.0 Wesley Ebisuzaki 2006
- * v1.1 Wesley Ebisuzaki 4/2007 netcdf support
- * v1.2 Wesley Ebisuzaki 4/2007 multiple table support
- * v1.3 Wesley Ebisuzaki 6/2011 make parameter cat >= 192 local
- * v1.4 Wesley Ebisuzaki 2/2012 fixed search_gribtab for local tables
- * v1.5 Wesley Ebisuzaki 4/2013 gribtab -> gribtable, added user_gribtable
- * v1.6 Wesley Ebisuzaki 1/2021 use NCEP or ECMWF names as default, local table handled epar
+
  */
 
+/** Indicates the GRIB table name to use */
 extern int names;
 
+/**
+ * Get the name information. 
+ * 
+ * @param sec Pointer to the GRIB section.
+ * @param mode Mode of operation (0 for normal, -1 for initialization).
+ * @param inv_out Pointer to the output string for the name. Ignored if NULL.
+ * @param name Pointer to store the name. Ignored if NULL.
+ * @param desc Pointer to store the description. Ignored if NULL.
+ * @param unit Pointer to store the unit. Ignored if NULL.
+ * @param mset Pointer to store the master table version number used by set_var.
+ * @param mlow Pointer to store the low range of master tables.
+ * @param mhigh Pointer to store the high range of master tables.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @author Wesley Ebisuzaki @date 2006
+ */
 int getName_all(unsigned char **sec, int mode, char *inv_out, char *name, char *desc, char *unit, int *mset, int *mlow, int *mhigh) {
 
     int discipline, center, mastertab, localtab, parmcat, parmnum;
@@ -132,16 +167,36 @@ int getName_all(unsigned char **sec, int mode, char *inv_out, char *name, char *
     return 0;
 }
 
+/**
+ * Get the name information. 
+ * 
+ * @param sec Pointer to the GRIB section.
+ * @param mode Mode of operation (0 for normal, -1 for initialization).
+ * @param inv_out Pointer to the output string for the name. Ignored if NULL.
+ * @param name Pointer to store the name. Ignored if NULL.
+ * @param desc Pointer to store the description. Ignored if NULL.
+ * @param unit Pointer to store the unit. Ignored if NULL.
+ * 
+ * @return 0 for success, error code otherwise.
+ * 
+ * @author Wesley Ebisuzaki @date 2006
+ */
 int getName(unsigned char **sec, int mode, char *inv_out, char *name, char *desc, char *unit) {
-        int mset, mlow, mhigh;
+    int mset, mlow, mhigh;
 
     return getName_all(sec, mode, inv_out, name, desc, unit, &mset, &mlow, &mhigh);
 }
 
-/*
- * search the grib table
- */
-
+ /**
+  * Searches the GRIB table for a matching entry based on the GRIB section.
+  * 
+  * @param p Pointer to the start of the GRIB table.
+  * @param sec Pointer to the GRIB section.
+  * 
+  * @return Pointer to the matching entry in the GRIB table, or NULL if not found.
+  * 
+  * @author Wesley Ebisuzaki @date 2006
+  */
 static struct gribtable_s *search_gribtable(struct gribtable_s *p, unsigned char **sec) {
 
     int discipline, center, mastertab, localtab, parmcat, parmnum;

--- a/wgrib2/cname.c
+++ b/wgrib2/cname.c
@@ -47,7 +47,7 @@ extern int names;
  * 
  * @param sec Pointer to the GRIB section.
  * @param mode Mode of operation (0 for normal, -1 for initialization).
- * @param inv_out Pointer to the output string for the name. Ignored if NULL.
+ * @param inv_out Pointer to the inventory output. Ignored if NULL.
  * @param name Pointer to store the name. Ignored if NULL.
  * @param desc Pointer to store the description. Ignored if NULL.
  * @param unit Pointer to store the unit. Ignored if NULL.
@@ -166,7 +166,7 @@ int getName_all(unsigned char **sec, int mode, char *inv_out, char *name, char *
  * 
  * @param sec Pointer to the GRIB section.
  * @param mode Mode of operation (0 for normal, -1 for initialization).
- * @param inv_out Pointer to the output string for the name. Ignored if NULL.
+ * @param inv_out Pointer to the inventory output. Ignored if NULL.
  * @param name Pointer to store the name. Ignored if NULL.
  * @param desc Pointer to store the description. Ignored if NULL.
  * @param unit Pointer to store the unit. Ignored if NULL.


### PR DESCRIPTION
Part of #208 

For wgrib2 option functions (those starting with f_*), the descriptions of the function arguments (ARG0, ARG1, etc.) have ??? as placeholders. I also have some placeholders for the "Example" sections. We need to work out how to handle these, but I would like to get the "easy" parts of the documentation done. I will modify the descriptions in future pull requests.