### PR TITLE
fix to ens_qc  issue #440

### DIFF
--- a/tests/run_gmerge_tests.sh
+++ b/tests/run_gmerge_tests.sh
@@ -18,5 +18,21 @@ do
 done
 
 ../aux_progs/gmerge tmp.gmerge.grb $arg
+
+
+echo "*** running gmerge and ens_qc test "
+
+../aux_progs/gmerge - $arg | ../wgrib2/wgrib2 - -ens_qc ens_qc.x ens_qc.y ens_qc.z 1 >/dev/null
+
+ck="1559805086 4891"
+newck=`../wgrib2/wgrib2 ens_qc.x -match spread -stats | cksum`
+echo "ck=$ck"
+echo "newck=$newck"
+if [ "$ck" != "$newck" ] ; then
+    echo "ck=$ck"
+    echo "newck=$newck"
+    echo "error in ens_qc"
+    exit 1
+fi
 echo "*** SUCCESS!"
 exit 0

--- a/wgrib2/Ens_qc.c
+++ b/wgrib2/Ens_qc.c
@@ -43,6 +43,9 @@
  * 12/2021: Public Domain: Wesley Ebisuzaki
  *  1/2020: Initial public release
  *  9/2023: faster by using SIMD
+ *  9/2025: fix race condition: could not observe race condition in multiple attempts
+ *             found by code examination, vulnerability may have been reduced
+ *             by code optimizer.
  */
 
 /* code table 4.7 */
@@ -128,16 +131,16 @@ static int init_ens_qc_struct(struct ens_qc_struct *save,
 //       save->verf_date.day, save->verf_date.hour);
 
     if (translation == NULL) {
-#ifdef USE_OPENMP
-#pragma omp parallel for private(i)
+#ifdef IS_OPENMP_4_0
+#pragma omp simd
 #endif
         for (i = 0; i < ndata; i++) {
 	    save->grids[i] = data[i];
 	}
     }
     else {
-#ifdef USE_OPENMP
-#pragma omp parallel for private(i)
+#ifdef IS_OPENMP_4_0
+#pragma omp simd
 #endif
         for (i = 0; i < ndata; i++) {
 	    save->grids[translation[i]] = data[i];
@@ -171,16 +174,16 @@ static int update_ens_qc_struct(struct ens_qc_struct *save,
        do it now because translation[] may be different in finalized phase */
 
     if (translation == NULL) {
-#ifdef USE_OPENMP
-#pragma omp parallel for private(i)
+#ifdef IS_OPENMP_4_0
+#pragma omp simd
 #endif
         for (i = 0; i < ndata; i++) {
 	    save->grids[i+save->n_ens*ndata] = data[i];
 	}
     }
     else {
-#ifdef USE_OPENMP
-#pragma omp parallel for private(i)
+#ifdef IS_OPENMP_4_0
+#pragma omp simd
 #endif
         for (i = 0; i < ndata; i++) {
 	    save->grids[translation[i]+save->n_ens*ndata] = data[i];
@@ -196,7 +199,7 @@ static int wrt_ens_qc(unsigned char **sec, struct ens_qc_struct *save) {
     int pdt, pdt_ens, k, k_0;
     unsigned int i, ndata;
     float *datamin, *datamax, *datavar, *datamean, *dataextreme, maxextreme;
-    float minval, maxval;
+    float minval, maxval, tmpf;
     double tmp, sum, sq;
     int n, n_grids;
     unsigned char sec4[SET_PDT_SIZE];
@@ -231,6 +234,9 @@ static int wrt_ens_qc(unsigned char **sec, struct ens_qc_struct *save) {
         fatal_error("ens_qc: new_pdt failed","");
 
     /* make a new sec[][] */
+#ifdef IS_OPENMP_4_0
+#pragma omp simd
+#endif
     for (i = 0; i < 9; i++) new_sec[i] = save->first_sec[i];
     new_sec[4] = sec4;
 
@@ -262,7 +268,7 @@ static int wrt_ens_qc(unsigned char **sec, struct ens_qc_struct *save) {
             fatal_error("ens_qc: memory allocation","");
 
 #ifdef USE_OPENMP
-#pragma omp parallel for private(i, k, sum, sq, k_0, n, minval, maxval), reduction (max:maxextreme)
+#pragma omp parallel for private(i, k, sum, sq, k_0, n, minval, maxval, tmp, tmpf), reduction (max:maxextreme)
 #endif
     for (i = 0; i < ndata; i++) {
 	sum = sq = 0;
@@ -278,12 +284,15 @@ static int wrt_ens_qc(unsigned char **sec, struct ens_qc_struct *save) {
 	   n = 1;
 
 	   /* calculate sum, min and max */
+#ifdef IS_OPENMP_4_0
+#pragma omp simd private(tmpf) reduction(+:sum,n) reduction(min: minval) reduction(max: maxval)
+#endif
 	   for (k = k_0 + 1; k < n_grids; k++) {
-		tmp = save->grids[i+k*ndata];
-		if (DEFINED_VAL(tmp)) {
-		    maxval = maxval > tmp ? maxval : tmp;
-		    minval = minval < tmp ? minval : tmp;
-		    sum += tmp;
+		tmpf = save->grids[i+k*ndata];
+		if (DEFINED_VAL(tmpf)) {
+		    maxval = maxval > tmpf ? maxval : tmpf;
+		    minval = minval < tmpf ? minval : tmpf;
+		    sum += tmpf;
 		    n++;
 		}
 	    }
@@ -295,12 +304,12 @@ static int wrt_ens_qc(unsigned char **sec, struct ens_qc_struct *save) {
 
 	    sq = 0;
 #ifdef IS_OPENMP_4_0
-#pragma omp simd private(tmp) reduction(+:sq)
+#pragma omp simd private(tmpf) reduction(+:sq)
 #endif
             for (k = k_0; k < n_grids; k++) {
-	        tmp = save->grids[i+k*ndata];
-                if (DEFINED_VAL(tmp)) {
-		    sq += (tmp - sum)*(tmp - sum);
+	        tmpf = save->grids[i+k*ndata];
+                if (DEFINED_VAL(tmpf)) {
+		    sq += (tmpf - sum)*(tmpf - sum);
 	        }
             }
 	    datavar[i] = sq = sqrt(sq/n);


### PR DESCRIPTION
Fixes issue #440.  "tmp" variable was declared private.
Added a new private variable "tmpf" which is floating point instead of double.
Made a loop simd.  Tested on a skylake with avx-512.  What a horrible avx-512
implementation.  Making a loop simd can be slower than non-simd!  