### PR TITLE
Address some level related issues mentioned in issue #449

### DIFF
--- a/wgrib2/Level.c
+++ b/wgrib2/Level.c
@@ -61,12 +61,12 @@ const char *level_table[192] = {
 /* 28 */ "reserved",
 /* 29 */ "reserved",
 /* 30 */ "specified radius from center of sun",
-/* 31 */ "ionosphere D-region level",
-/* 32 */ "ionosphere E-region level",
-/* 33 */ "reserved",
-/* 34 */ "reserved",
-/* 35 */ "reserved",
-/* 36 */ "reserved",
+/* 31 */ "solar photosphere",
+/* 32 */ "ionosphere D-region level",
+/* 33 */ "ionosphere E-region level",
+/* 34 */ "ionosphere F1-region level",
+/* 35 */ "ionosphere F2-region level",
+/* 36 */ "stratopause",
 /* 37 */ "reserved",
 /* 38 */ "reserved",
 /* 39 */ "reserved",
@@ -196,7 +196,7 @@ const char *level_table[192] = {
 /* 163 */ "bottom of sediment layer",
 /* 164 */ "bottom of thermally active sediment layer",
 /* 165 */ "bottom of sediment layer penetrated by thermal wave",
-/* 166 */ "maxing layer",
+/* 166 */ "mixing layer",
 /* 167 */ "bottom of root zone",
 /* 168 */ "ocean model level %g",
 /* 169 */ "ocean level %g (kg*m-3) density difference to near surface",
@@ -539,12 +539,12 @@ int level1(int mode, int type, int undef_val, float val, int center, int subcent
 
     /* local table for NCEP */
     if (center == NCEP && type >= 192 && type <= 254) {
-        if (type == 235) val *= 0.01;  // C -> 0.1C
+        if (type == 235) val *= 0.1;  // 0.1C -> C
         sprintf(inv_out,ncep_level_table[type-192], val);
     }
 
     else if (center == KMA && type >= 192 && type <= 254) {
-        if (type == 235) val *= 0.01;  // C -> 0.1C
+        if (type == 235) val *= 0.1;  // 0.1C -> C
         sprintf(inv_out,kma_level_table[type-192], val);
     }
 

--- a/wgrib2/Mod_grib.c
+++ b/wgrib2/Mod_grib.c
@@ -404,8 +404,8 @@ int f_set_lev(ARG1) {
         return 0;
     }
 
-    if (strcmp("atmos col", arg1) == 0 ||	// wgrib2 compatible
-            strcmp("Entire atmosphere (considered as a single layer)", arg1) == 0) {
+    if (strcmp("atmos col", arg1) == 0 ||	// wgrib compatible
+            strcmp("entire atmosphere (considered as a single layer)", arg1) == 0) {
         if (p2 == NULL) fatal_error("set_lev: PDT has only 1 fixed surface, set_lev needs 2","");
         p1[0] = 1;
         p2[0] = 8;


### PR DESCRIPTION
Part of #449 

- shift entries 31 and 32 of table 4.5 by one and add surrounding new entries. Entries are converted to lower case to match general style
- fix spelling issue of entry 166 of table 4.5: maxing -> mixing
- fix numerical conversion 0.1C -> C of entry 235 (NCEP addition to table 4.5)
- fix "Entire atmosphere" string in Mod_grib.c to match entry in Level.c