### PR TITLE
fix undef warnings partial fix for #444

### DIFF
--- a/wgrib2/New_grid.c
+++ b/wgrib2/New_grid.c
@@ -1542,6 +1542,8 @@ int f_new_grid(ARG4) {
 
 #ifndef USE_IPOLATES
 int f_new_grid_vectors(ARG1) {
+    (void) UV_vectors;
+    (void) no_vectors;
     fprintf(stderr,"IPOLATES package is not installed\n");
     return 1;
 }

--- a/wgrib2/Sec3.c
+++ b/wgrib2/Sec3.c
@@ -990,7 +990,7 @@ int f_grid(ARG0) {
                 sprintf(inv_out,"sat. altitude=infinity (equatorial radii) grid_origin Xo=%d Yo=%d", 
                         GDS_Space_x0(gds), GDS_Space_y0(gds));
 
-                break;
+            break;
             case 100: sprintf(inv_out,"Triangular grid based on icosahedron");
                 break;
 

--- a/wgrib2/Set_gds.c
+++ b/wgrib2/Set_gds.c
@@ -37,8 +37,12 @@ int f_set_gds(ARG1) {
 
     if (mode < 0) return 0;
     size_new_sec3 = atoi(arg1);
-    if (size_new_sec3 <  5) fatal_error("set_gdt: X=length of GDT (Sec 3)","");
-    new_sec3 = (unsigned char *) malloc(sizeof(unsigned char) * (size_t) size_new_sec3);
+    if (size_new_sec3 <  5) {
+        fatal_error("set_gdt: X=length of GDT (Sec 3)","");
+        /* is needed to remove compiler warning */
+        exit(1);
+    }
+    new_sec3 = (unsigned char *) malloc((size_t) (sizeof(unsigned char) * size_new_sec3));
     if (new_sec3 == NULL) fatal_error("new_gds: memory allocation","");
 
     /* size of sec3 */

--- a/wgrib2/Spectral_bands.c
+++ b/wgrib2/Spectral_bands.c
@@ -42,6 +42,9 @@ int f_spectral_bands_extname(ARG0) {
     double c=299792458.;
     double minwave=9e19, maxwave=-9e19, sumwave=0, wl, fq;
 
+    (void) agency;
+    (void) longname;
+
     int multisat=0, multipol=0;
 
     if (mode < 0) return 0;

--- a/wgrib2/c_api/grb2_wrt.c
+++ b/wgrib2/c_api/grb2_wrt.c
@@ -44,9 +44,7 @@ int grb2_wrtVA(const char *grb, const char *template, int msgno, float *data,
     char *option, *str_arg;
     int i, ierr;
     long long int ival8;
-    size_t bufsize;
     char line[100];
-    char buffer[71];
 
     /* copy data to register 9, check for size mismatch is internal to wgrib2(..)  */
 

--- a/wgrib2/complex_pk.c
+++ b/wgrib2/complex_pk.c
@@ -1044,7 +1044,10 @@ fprintf(stderr,"complex_pk: linked list ngroups=%u\n", ngroups);
         itmp[ii] = s->mx;
         itmp2[ii] = s->missing;
     }
-    if (i != nndata) fatal_error("complex grib_out: program error 2","");
+    if (i != nndata) {
+        fatal_error("complex grib_out: program error 2","");
+        exit(1);
+    }
 
 #ifdef USE_OPENMP
 #pragma omp parallel for private(i)

--- a/wgrib2/gctpc/source/stplnfor.c
+++ b/wgrib2/gctpc/source/stplnfor.c
@@ -151,9 +151,9 @@ if (ptr == NULL)
       return(22);
       }
 fseek(ptr,(ind) * 432, 0);
-fread(pname,1,32,ptr);
-fread(&id,sizeof(long),1,ptr);
-fread(table,sizeof(double),9,ptr);
+if (fread(pname,1,32,ptr)) return ERROR;
+if (fread(&id,sizeof(long),1,ptr)) return ERROR;
+if (fread(table,sizeof(double),9,ptr)) return ERROR;
 fclose(ptr);
   
 if (id <= 0)

--- a/wgrib2/gctpc/source/stplninv.c
+++ b/wgrib2/gctpc/source/stplninv.c
@@ -93,6 +93,7 @@ char buf[100];		/* buffer for error messages */
 double r_maj,r_min,scale_fact,center_lon;
 double center_lat,false_east,false_north;
 double azimuth,lat_orig,lon_orig,lon1,lat1,lon2,lat2;
+int err;
 long mode,iflg;
 FILE *ptr;
 
@@ -150,10 +151,13 @@ if (ptr == NULL)
    p_error("Error opening State Plane parameter file","state-inv");
    return(22);
    }
-fseek(ptr,ind  * 432, 0);
-fread(pname,sizeof(char),32,ptr);
-fread(&id,sizeof(long),1,ptr);
-fread(table,sizeof(double),9,ptr);
+err=fseek(ptr,ind  * 432, 0);
+if (err) return(ERROR);
+err=fread(pname,sizeof(char),32,ptr);
+if (err) return(ERROR);
+err=fread(&id,sizeof(long),1,ptr);
+if (err) return(ERROR);
+err=fread(table,sizeof(double),9,ptr);
 fclose(ptr);
    
 if (id <= 0)

--- a/wgrib2/space_view2ij.c
+++ b/wgrib2/space_view2ij.c
@@ -53,7 +53,7 @@
 extern double *lat;
 
 /** Pointer to array of longitude values. */
-static double *lon;
+// static double *lon;
 
 /** Current output order type. */
 extern enum output_order_type output_order;


### PR DESCRIPTION
Part of #444 

Remove warning when compiling default version of wgrib2 using gcc v13.3.0.

Not all warning are removed.
  omerinv and omerfor fix is another pull request
  wgrib errors will be fixed in a future pull request that
    changes wgrib.c to the development *.c and *.h files