### PR TITLE
Spectral bands #450

### DIFF
--- a/wgrib2/Spectral_bands.c
+++ b/wgrib2/Spectral_bands.c
@@ -132,8 +132,8 @@ int f_spectral_bands_extname(ARG0) {
         if(minwave*1.01<maxwave)
             sprintf(inv_out,"%d bands: %.3g to %.3g m-1 ",nb,minwave,maxwave);
         else {
-            wl=1.e6/value;
-            fq=c*value/1e9;
+            wl=1.e6/sumwave;
+            fq=c*sumwave/1e9;
             if     (wl>0.1  && wl<100 )  sprintf(inv_out,"%.2f um ",wl);
             else if(fq>1    && fq<1000)  sprintf(inv_out,"%.2f GHz ",fq);
             else                         sprintf(inv_out,"%.3g m-1 ",minwave);

--- a/wgrib2/Spectral_bands.c
+++ b/wgrib2/Spectral_bands.c
@@ -42,7 +42,7 @@ int f_spectral_bands_extname(ARG0) {
     
     const char *shortname1=NULL, *satellite1=NULL, *pol1=NULL;
     double c=299792458.;
-    double minwave=9e19, maxwave=-9e19, sumwave=0, wl, fq;
+    double minwave=9e19, maxwave=-9e19, sumwave=0.0, wl, fq;
 
     (void) agency;
     (void) longname;
@@ -126,18 +126,20 @@ int f_spectral_bands_extname(ARG0) {
             sprintf(inv_out,"Ins %d ",instrument);
         inv_out+=strlen(inv_out);
     }
-        
-    if(minwave*1.01<maxwave)
-        sprintf(inv_out,"%d bands: %.3g to %.3g m-1 ",nb,minwave,maxwave);
-    else {
-        wl=1.e6/value;
-        fq=c*value/1e9;
-        if     (wl>0.1  && wl<100 )  sprintf(inv_out,"%.2f um ",wl);
-        else if(fq>1    && fq<1000)  sprintf(inv_out,"%.2f GHz ",fq);
-        else                         sprintf(inv_out,"%.3g m-1 ",minwave);
 
+    if (nb > 0) {
+        sumwave /= nb;
+        if(minwave*1.01<maxwave)
+            sprintf(inv_out,"%d bands: %.3g to %.3g m-1 ",nb,minwave,maxwave);
+        else {
+            wl=1.e6/value;
+            fq=c*value/1e9;
+            if     (wl>0.1  && wl<100 )  sprintf(inv_out,"%.2f um ",wl);
+            else if(fq>1    && fq<1000)  sprintf(inv_out,"%.2f GHz ",fq);
+            else                         sprintf(inv_out,"%.3g m-1 ",minwave);
+        }
+        inv_out+=strlen(inv_out);
     }
-    inv_out+=strlen(inv_out);
 
     if(multipol) 
         strcat(inv_out,"mult.pol.");


### PR DESCRIPTION
Updates Spectral_bands.c.  Now handles the case when there are no spectral bands and  uses the unused sumwave by printing some statistics by using sumwave/nb instead of the last wavenumber in the case when min and max wave number are within 1% of each other.