### PR TITLE
Merge error in Sec1.c

### DIFF
--- a/wgrib2/Sec1.c
+++ b/wgrib2/Sec1.c
@@ -269,12 +269,7 @@ int f_subcenter(ARG0) {
     if (mode >= 0) {
         ctr = GB2_Center(sec);
         subctr = GB2_Subcenter(sec);
-	      string = NULL;
-	      if (ctr == 7) {
-          switch (subctr) {
-#include "CommonCodeTable_12.dat"
-           }
-        }
+        string = NULL;
         if (ctr == (USAF)) {
             switch (subctr) {
 #include "gribtables/usaf/usaf_tableC2.dat"


### PR DESCRIPTION
Fixes #469 
Delete duplicate inclusion of CommonCodeTable_12.dat. USAF code will be overwritten, if ever some USAF entries are present in CommonCodeTable_12.dat, but that is most probably fine.